### PR TITLE
copy operations final cleanups

### DIFF
--- a/doc/spec/source/algorithms/copy.rst
+++ b/doc/spec/source/algorithms/copy.rst
@@ -15,13 +15,12 @@ Interface
 
 .. doxygenfunction:: lib::copy(DI first, DI last, mpi_distributed_contiguous_iterator auto result)
 .. doxygenfunction:: lib::copy(mpi_distributed_contiguous_range auto &&r, mpi_distributed_contiguous_iterator auto result)
-.. doxygenfunction:: lib::copy(int root, I first, I last, mpi_distributed_contiguous_iterator auto result)
-.. doxygenfunction:: lib::copy(int root, std::contiguous_iterator auto first, std::size_t size, mpi_distributed_contiguous_iterator auto result)
-.. doxygenfunction:: lib::copy(int root, std::nullptr_t, std::size_t size, mpi_distributed_contiguous_iterator auto result)
+.. doxygenfunction:: lib::copy(int root, contiguous_iterator_or_nullptr auto first, std::size_t size, mpi_distributed_contiguous_iterator auto result)
+.. doxygenfunction:: lib::copy(int root, IN first, IN last, mpi_distributed_contiguous_iterator auto result)
 .. doxygenfunction:: lib::copy(int root, rng::contiguous_range auto &&r, mpi_distributed_contiguous_iterator auto result)
-.. doxygenfunction:: lib::copy(int root, DI first, DI last, IN result)
-.. doxygenfunction:: lib::copy(int root, DI first, std::size_t size, std::contiguous_iterator auto result)
-.. doxygenfunction:: lib::copy(int root, mpi_distributed_contiguous_range auto &&r, auto result)
+.. doxygenfunction:: lib::copy(int root, DI first, DI last, contiguous_iterator_or_nullptr auto result)
+.. doxygenfunction:: lib::copy(int root, mpi_distributed_contiguous_iterator auto first, std::size_t size, contiguous_iterator_or_nullptr auto result)
+.. doxygenfunction:: lib::copy(int root, mpi_distributed_contiguous_range auto &&r, contiguous_iterator_or_nullptr auto result)
 
 Description
 ===========

--- a/include/dr/algorithms/algorithms.hpp
+++ b/include/dr/algorithms/algorithms.hpp
@@ -172,8 +172,8 @@ template <class It> inline void *it2raw(It it) { return &*it; }
 } // unnamed namespace
 
 /// Collective copy from local begin/end to distributed iterator.
-/// On the non-root rank the `first` param is ignored and may be a `nullptr`.
-/// Size of the source needs to be provided on all ranks.
+/// On the non-root rank the `first` parameter is ignored and may be a
+/// `nullptr`. Size of the source needs to be provided on all ranks.
 void copy(int root, contiguous_iterator_or_nullptr auto first, std::size_t size,
           mpi_distributed_contiguous_iterator auto result) {
   if (size == 0)

--- a/include/dr/algorithms/algorithms.hpp
+++ b/include/dr/algorithms/algorithms.hpp
@@ -194,8 +194,8 @@ void copy(int root, contiguous_iterator_or_nullptr auto first, std::size_t size,
 }
 
 /// Collective copy from local begin/end to distributed iterator.
-/// On the non-root rank the 'first' and 'last' parameters are ignored and may
-/// be a 'nullptr'.
+/// On the non-root rank the `first` and `last` parameters are ignored and may
+/// be a `nullptr`.
 template <contiguous_iterator_or_nullptr IN>
 void copy(int root, IN first, IN last,
           mpi_distributed_contiguous_iterator auto result) {
@@ -216,8 +216,8 @@ void copy(int root, rng::contiguous_range auto &&r,
 }
 
 /// Collective copy from distributed begin/end to local iterator.
-/// On the non-root rank the 'result' parameter is ignored and may be a
-/// 'nullptr'.
+/// On the non-root rank the `result` parameter is ignored and may be a
+/// `nullptr`.
 template <mpi_distributed_contiguous_iterator DI>
 void copy(int root, DI first, DI last,
           contiguous_iterator_or_nullptr auto result) {
@@ -233,16 +233,16 @@ void copy(int root, DI first, DI last,
 }
 
 /// Collective copy from distributed begin/end to local iterator.
-/// On the non-root rank the 'result' parameter is ignored and may be a
-/// 'nullptr'.
+/// On the non-root rank the `result` parameter is ignored and may be a
+/// `nullptr`.
 void copy(int root, mpi_distributed_contiguous_iterator auto first,
           std::size_t size, contiguous_iterator_or_nullptr auto result) {
   lib::copy(root, first, first + size, result);
 }
 
 /// Collective copy from distributed range to local iterator.
-/// On the non-root rank the 'result' parameter is ignored and may be a
-/// 'nullptr'.
+/// On the non-root rank the `result` parameter is ignored and may be a
+/// `nullptr`.
 void copy(int root, mpi_distributed_contiguous_range auto &&r,
           contiguous_iterator_or_nullptr auto result) {
   lib::copy(root, r.begin(), r.end(), result);

--- a/include/dr/details/communicator.hpp
+++ b/include/dr/details/communicator.hpp
@@ -38,7 +38,7 @@ public:
 
     void get(void *dst, int size, int rank, int disp) const {
       MPI_Request request;
-      MPI_Rget(dst, size, MPI_CHAR, rank, disp, size, MPI_CHAR, win_, &request);
+      MPI_Rget(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
       MPI_Wait(&request, MPI_STATUS_IGNORE);
     }
 
@@ -47,7 +47,7 @@ public:
     }
 
     void put(const void *src, int size, int rank, int disp) const {
-      MPI_Put(src, size, MPI_CHAR, rank, disp, size, MPI_CHAR, win_);
+      MPI_Put(src, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_);
     }
 
     void fence() const {
@@ -80,38 +80,42 @@ public:
 
   void barrier() const { MPI_Barrier(mpi_comm_); }
 
+  void bcast(void *src, size_t count, int root) const {
+    MPI_Bcast(src, count, MPI_BYTE, root, mpi_comm_);
+  }
+
   void scatter(const void *src, void *dst, int size, int root) const {
-    MPI_Scatter(src, size, MPI_CHAR, dst, size, MPI_CHAR, root, mpi_comm_);
+    MPI_Scatter(src, size, MPI_BYTE, dst, size, MPI_BYTE, root, mpi_comm_);
   }
 
   void scatterv(const void *src, int *counts, int *offsets, void *dst,
                 int dst_count, int root) const {
     assert(counts == nullptr || counts[rank()] == dst_count);
-    MPI_Scatterv(src, counts, offsets, MPI_CHAR, dst, dst_count, MPI_CHAR, root,
+    MPI_Scatterv(src, counts, offsets, MPI_BYTE, dst, dst_count, MPI_BYTE, root,
                  mpi_comm_);
   }
 
   void gather(const void *src, void *dst, int size, int root) const {
-    MPI_Gather(src, size, MPI_CHAR, dst, size, MPI_CHAR, root, mpi_comm_);
+    MPI_Gather(src, size, MPI_BYTE, dst, size, MPI_BYTE, root, mpi_comm_);
   }
 
   template <typename T>
   void gather(const T &src, std::vector<T> &dst, int root) const {
     dst.resize(size());
-    MPI_Gather(&src, sizeof(src), MPI_CHAR, dst.data(), sizeof(src), MPI_CHAR,
+    MPI_Gather(&src, sizeof(src), MPI_BYTE, dst.data(), sizeof(src), MPI_BYTE,
                root, mpi_comm_);
   }
 
   void gatherv(const void *src, int *counts, int *offsets, void *dst,
                int root) const {
-    MPI_Gatherv(src, counts[rank()], MPI_CHAR, dst, counts, offsets, MPI_CHAR,
+    MPI_Gatherv(src, counts[rank()], MPI_BYTE, dst, counts, offsets, MPI_BYTE,
                 root, mpi_comm_);
   }
 
   template <typename T>
   void isend(const T *data, int size, int source, tag t,
              MPI_Request *request) const {
-    MPI_Isend(data, size * sizeof(T), MPI_CHAR, source, int(t), mpi_comm_,
+    MPI_Isend(data, size * sizeof(T), MPI_BYTE, source, int(t), mpi_comm_,
               request);
   }
 
@@ -122,7 +126,7 @@ public:
 
   template <typename T>
   void irecv(T *data, int size, int dest, tag t, MPI_Request *request) const {
-    MPI_Irecv(data, size * sizeof(T), MPI_CHAR, dest, int(t), mpi_comm_,
+    MPI_Irecv(data, size * sizeof(T), MPI_BYTE, dest, int(t), mpi_comm_,
               request);
   }
 

--- a/test/fuzz/cpu/cpu-fuzz.cpp
+++ b/test/fuzz/cpu/cpu-fuzz.cpp
@@ -55,12 +55,12 @@ struct fuzz_spec {
 
 extern "C" int LLVMFuzzerTestOneInput(const fuzz_spec *my_spec, size_t size) {
   // Controller broadcasts its fuzz spec
-  MPI_Bcast(&size, sizeof(size), MPI_CHAR, controller_rank, comm);
+  MPI_Bcast(&size, sizeof(size), MPI_BYTE, controller_rank, comm);
   if (sizeof(fuzz_spec) < size)
     return 0;
 
   auto spec = *my_spec;
-  MPI_Bcast(&spec, sizeof(spec), MPI_CHAR, controller_rank, comm);
+  MPI_Bcast(&spec, sizeof(spec), MPI_BYTE, controller_rank, comm);
 
   auto n = spec.n;
   auto b = spec.b;

--- a/test/gtest/cpu/algorithms.cpp
+++ b/test/gtest/cpu/algorithms.cpp
@@ -12,7 +12,7 @@ void check_copy(std::size_t n, std::size_t b, std::size_t e) {
   rng::iota(v_in, 100);
 
   lib::distributed_vector<int> dv_in(n), dv1(n), dv2(n), dv3(n), dv4(n), dv5(n),
-      dv6(n), dv7(n);
+      dv6(n), dv7(n), dv8(n), dv9(n);
   lib::iota(dv_in, 100);
   lib::copy(dv_in.begin() + b, dv_in.begin() + e, dv1.begin() + b);
   lib::copy(rng::subrange(dv_in.begin() + b, dv_in.begin() + e),
@@ -46,6 +46,15 @@ void check_copy(std::size_t n, std::size_t b, std::size_t e) {
   lib::copy(0, dv_in.begin() + b, dv_in.begin() + e,
             comm_rank == 0 ? &*(v3.begin() + b) : nullptr);
 
+  if (comm_rank == 0) {
+    lib::copy(0, v_in.begin() + b, v_in.begin() + e, dv8.begin() + b);
+  } else {
+    lib::copy(0, nullptr, nullptr, dv8.begin() + b);
+  }
+
+  lib::copy(0, comm_rank == 0 ? &*(v_in.begin() + b) : nullptr,
+            comm_rank == 0 ? &*(v_in.begin() + e) : nullptr, dv9.begin() + b);
+
   dv3.fence();
 
   if (comm_rank == 0) {
@@ -58,6 +67,8 @@ void check_copy(std::size_t n, std::size_t b, std::size_t e) {
     EXPECT_TRUE(equal(dv5, v));
     EXPECT_TRUE(equal(dv6, v));
     EXPECT_TRUE(equal(dv7, v));
+    EXPECT_TRUE(equal(dv8, v));
+    EXPECT_TRUE(equal(dv9, v));
 
     EXPECT_TRUE(equal(v1, v));
     EXPECT_TRUE(equal(v2, v));


### PR DESCRIPTION
I tried to clean up all the stuff related to copy
- functions are in SPMD style (one function accepting either iterators or nullptr)
- functions have consistent signatures ('concept auto name' whenever possible instead of template, unless we need the same type for two params)
- functions have short consistent comments

Maybe it is not best to review the change itself (or not only to review the change), but to look how all copy functions currently look and if we like how do they look.

PR is based on https://github.com/oneapi-src/distributed-ranges/pull/4