### PR TITLE
Add template overloads for transpose

### DIFF
--- a/include/dr/algorithms/transpose.hpp
+++ b/include/dr/algorithms/transpose.hpp
@@ -348,6 +348,19 @@ inline void transpose(int root,
   }
 }
 
+template <typename T, typename T2 = std::nullopt_t,
+          typename DExtents> // layout_right only arrays
+inline void transpose(int root, T2 src, distributed_mdarray<T, DExtents> &dst) {
+  transpose(root, std::optional<std::experimental::mdspan<T, DExtents>>(), dst);
+}
+
+template <typename T, typename T2 = std::nullopt_t,
+          typename SExtents> // layout_right only arrays
+inline void transpose(int root, const distributed_mdarray<T, SExtents> &src,
+                      T2 dst) {
+  transpose(root, src, std::optional<std::experimental::mdspan<T, SExtents>>());
+}
+
 template <mdspan_2d src_type, mdspan_2d dst_type>
 inline void transpose(const src_type &src, dst_type &dst) {
   if constexpr (mdspan_regular<src_type> && mdspan_regular<dst_type> &&

--- a/include/dr/algorithms/transpose.hpp
+++ b/include/dr/algorithms/transpose.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <optional>
+
 namespace lib {
 
 template <typename T>
@@ -295,6 +297,54 @@ inline void transpose(const distributed_mdarray<T, Extents> &src,
     t.compute_for_me();
     t.send_receive_wait(t.num_proc - 1);
     t.dst_write(t.num_proc - 1);
+  }
+}
+
+template <typename T, typename SExtents,
+          typename DExtents> // layout_right only arrays
+inline void
+transpose(int root, const distributed_mdarray<T, SExtents> &src,
+          std::optional<std::experimental::mdspan<T, DExtents>> dst) {
+  assert(dst.has_value() || root != src.comm().rank());
+  std::vector<T> local_vec;
+
+  if (src.comm().rank() == root) {
+    assert(src.extents().extent(0) == dst.value().extent(1));
+    assert(src.extents().extent(1) == dst.value().extent(0));
+
+    size_t n = src.extents().extent(0) * src.extents().extent(1);
+    local_vec.resize(n);
+  }
+
+  lib::copy(root, src.begin(), src.end(), local_vec.begin());
+
+  if (src.comm().rank() == root) {
+    transpose_local(src.extents().extent(0), src.extents().extent(1),
+                    local_vec.data(), src.extents().extent(1),
+                    dst.value().data_handle(), dst.value().extent(1));
+  }
+}
+
+template <typename T, typename SExtents,
+          typename DExtents> // layout_right only arrays
+inline void transpose(int root,
+                      std::optional<std::experimental::mdspan<T, SExtents>> src,
+                      distributed_mdarray<T, DExtents> &dst) {
+  assert(src.has_value() || root != dst.comm().rank());
+
+  if (dst.comm().rank() == root) {
+    assert(dst.extents().extent(0) == src.value().extent(1));
+    assert(dst.extents().extent(1) == src.value().extent(0));
+
+    std::vector<T> local_vec;
+    size_t n = dst.extents().extent(0) * dst.extents().extent(1);
+    local_vec.resize(n);
+    transpose_local(src.value().extent(0), src.value().extent(1),
+                    src.value().data_handle(), src.value().extent(1),
+                    local_vec.data(), dst.extents().extent(1));
+    lib::copy(root, local_vec.begin(), local_vec.end(), dst.begin());
+  } else {
+    lib::copy(root, nullptr, nullptr, dst.begin());
   }
 }
 

--- a/test/gtest/cpu/cpu-tests.hpp
+++ b/test/gtest/cpu/cpu-tests.hpp
@@ -13,12 +13,23 @@ extern int comm_rank;
 extern int comm_size;
 
 inline void expect_eq(const lib::mdspan_2d auto &m1,
-                      const lib::mdspan_2d auto &m2, int root = comm_rank) {
+                      const lib::mdspan_2d auto &m2,
+                      bool second_as_transposed = false, int root = comm_rank) {
   if (comm_rank == root) {
-    EXPECT_TRUE(m1.extents() == m2.extents());
+    if (second_as_transposed) {
+      EXPECT_TRUE(m1.extents().extent(0) == m2.extents().extent(1));
+      EXPECT_TRUE(m1.extents().extent(1) == m2.extents().extent(0));
+    } else {
+      EXPECT_TRUE(m1.extents() == m2.extents());
+    }
+
     for (std::size_t i = 0; i < m1.extents().extent(0); i++) {
       for (std::size_t j = 0; j < m1.extents().extent(1); j++) {
-        EXPECT_EQ(m1(i, j), m2(i, j));
+        if (second_as_transposed) {
+          EXPECT_EQ(m1(i, j), m2(j, i));
+        } else {
+          EXPECT_EQ(m1(i, j), m2(i, j));
+        }
       }
     }
   }

--- a/test/gtest/cpu/mdspan.cpp
+++ b/test/gtest/cpu/mdspan.cpp
@@ -192,9 +192,7 @@ TEST(CpuMpiTests, distribute_to_local_transpose) {
   }
 
   if (comm_rank == 0) {
-    EXPECT_EQ(dsrc(0, 0), ldst(0, 0));
-    EXPECT_EQ(dsrc(1, 0), ldst(0, 1));
-    EXPECT_EQ(dsrc(rows - 1, cols - 2), ldst(cols - 2, rows - 1));
+    expect_eq(dsrc, ldst, true);
   }
 }
 
@@ -219,8 +217,6 @@ TEST(CpuMpiTests, local_to_distribute_transpose) {
   }
 
   if (comm_rank == 0) {
-    EXPECT_EQ(lsrc(0, 0), ddst(0, 0));
-    EXPECT_EQ(lsrc(1, 0), ddst(0, 1));
-    EXPECT_EQ(lsrc(rows - 1, cols - 2), ddst(cols - 2, rows - 1));
+    expect_eq(lsrc, ddst, true);
   }
 }

--- a/test/gtest/cpu/mdspan.cpp
+++ b/test/gtest/cpu/mdspan.cpp
@@ -187,8 +187,7 @@ TEST(CpuMpiTests, distribute_to_local_transpose) {
   if (comm_rank == 0) {
     lib::collective::transpose(0, dsrc, std::make_optional(ldst));
   } else {
-    lib::collective::transpose(
-        0, dsrc, std::optional<std::experimental::mdspan<T, dyn_2d>>());
+    lib::collective::transpose(0, dsrc, std::nullopt);
   }
 
   if (comm_rank == 0) {
@@ -212,8 +211,7 @@ TEST(CpuMpiTests, local_to_distribute_transpose) {
   if (comm_rank == 0) {
     lib::collective::transpose(0, std::make_optional(lsrc), ddst);
   } else {
-    lib::collective::transpose(
-        0, std::optional<std::experimental::mdspan<T, dyn_2d>>(), ddst);
+    lib::collective::transpose(0, std::nullopt, ddst);
   }
 
   if (comm_rank == 0) {


### PR DESCRIPTION
Following PR introduces the possibility to easily pass `std::nullopt` for `transpose()` as substitution of `std::optional<T, DExtents>`.
The generic template requires that the underlying type of `mdspan` and `mdarray` is the same and prevents from passing `std::nullopt`.

Disclaimer:
Depends on #8