### PR TITLE
conformant function simplified

### DIFF
--- a/include/dr/mhp/algorithms/cpu_algorithms.hpp
+++ b/include/dr/mhp/algorithms/cpu_algorithms.hpp
@@ -31,9 +31,8 @@ void fill(DI first, DI last, auto value) {
 //
 
 template <lib::distributed_contiguous_range DR_IN, typename DI_OUT>
-void copy(DR_IN &&in, DI_OUT &&out) {
-  auto &&[conforms, constraint] = conformant(in.begin(), out);
-  if (conforms) {
+void copy(DR_IN &&in, DI_OUT out) {
+  if (conformant(in.begin(), out)) {
     for (const auto &&[in_seg, out_seg] :
          rng::views::zip(local_segments(in), local_segments(out))) {
       rng::copy(in_seg, out_seg.begin());

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -6,19 +6,14 @@ namespace mhp {
 
 // Base case. Anything conforms with itself.
 // template <lib::distributed_iterator It> auto conformant(It &&iter) {
-auto conformant_impl(lib::distributed_iterator auto iter) {
-  return std::pair(true, iter);
-}
+
+bool conformant(lib::distributed_iterator auto) { return true; }
 
 // Recursive case. This iterator conforms with the rest.
-auto conformant_impl(lib::distributed_iterator auto iter,
-                     lib::distributed_iterator auto... iters) {
-  auto &&[rest_conforms, constraining_iter] = conformant_impl(iters...);
-  return std::pair(rest_conforms && iter.conforms(constraining_iter), iter);
-}
-
-bool conformant(lib::distributed_iterator auto... iters) {
-  return conformant_impl(iters...).first;
+bool conformant(lib::distributed_iterator auto iter,
+                lib::distributed_iterator auto iter2,
+                lib::distributed_iterator auto... iters) {
+  return iter.conforms(iter2) && conformant(iter2, iters...);
 }
 
 #if 0

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -6,16 +6,19 @@ namespace mhp {
 
 // Base case. Anything conforms with itself.
 // template <lib::distributed_iterator It> auto conformant(It &&iter) {
-template <typename It> auto conformant(It &&iter) {
+auto conformant_impl(lib::distributed_iterator auto iter) {
   return std::pair(true, iter);
 }
 
 // Recursive case. This iterator conforms with the rest.
-template <lib::distributed_iterator It, typename... Its>
-auto conformant(It &&iter, Its &&...iters) {
-  auto &&[rest_conforms, constraining_iter] =
-      conformant(std::forward<Its>(iters)...);
+auto conformant_impl(lib::distributed_iterator auto iter,
+                     lib::distributed_iterator auto... iters) {
+  auto &&[rest_conforms, constraining_iter] = conformant_impl(iters...);
   return std::pair(rest_conforms && iter.conforms(constraining_iter), iter);
+}
+
+bool conformant(lib::distributed_iterator auto... iters) {
+  return conformant_impl(iters...).first;
 }
 
 #if 0

--- a/test/gtest/mhp/conformance.cpp
+++ b/test/gtest/mhp/conformance.cpp
@@ -14,10 +14,10 @@ TEST(MhpTests, IteratorConformance) {
   V v1(10);
 
   // 2 distributed vectors
-  EXPECT_TRUE(conformant(dv1.begin(), dv2.begin()).first);
+  EXPECT_TRUE(conformant(dv1.begin(), dv2.begin()));
   ;
   // misaligned distributed vector
-  EXPECT_FALSE(conformant(dv1.begin() + 1, dv2.begin()).first);
+  EXPECT_FALSE(conformant(dv1.begin() + 1, dv2.begin()));
 
   // iota conformant with anything
   // EXPECT_TRUE(conformant(dv1.begin(), rng::views::iota(1)).first);

--- a/test/gtest/mhp/conformance.cpp
+++ b/test/gtest/mhp/conformance.cpp
@@ -15,9 +15,12 @@ TEST(MhpTests, IteratorConformance) {
 
   // 2 distributed vectors
   EXPECT_TRUE(conformant(dv1.begin(), dv2.begin()));
+  EXPECT_TRUE(conformant(dv1.begin(), dv2.begin(), dv1.begin()));
   ;
   // misaligned distributed vector
   EXPECT_FALSE(conformant(dv1.begin() + 1, dv2.begin()));
+  EXPECT_FALSE(conformant(dv1.begin() + 1, dv2.begin(), dv2.begin()));
+  EXPECT_FALSE(conformant(dv2.begin(), dv1.begin() + 1, dv2.begin()));
 
   // iota conformant with anything
   // EXPECT_TRUE(conformant(dv1.begin(), rng::views::iota(1)).first);


### PR DESCRIPTION
- iterators are used to be taked by value in STL (let's don't use references to iterator, references to iterators do not satisfy std::forward_iterator concept)
- conformat uses now distributed_iterator types only
- simply returns bool