### PR TITLE
mhp support for rng::zip_view

### DIFF
--- a/include/dr/concepts/concepts.hpp
+++ b/include/dr/concepts/concepts.hpp
@@ -99,8 +99,4 @@ concept distributed_range_zip = requires(ZR &zr) {
                                   { std::get<0>(*zr.begin()) };
                                 };
 
-template <typename I>
-concept is_zip_iterator =
-    std::forward_iterator<I> && requires(I &iter) { std::get<0>(*iter); };
-
 } // namespace lib

--- a/include/dr/concepts/concepts.hpp
+++ b/include/dr/concepts/concepts.hpp
@@ -99,4 +99,8 @@ concept distributed_range_zip = requires(ZR &zr) {
                                   { std::get<0>(*zr.begin()) };
                                 };
 
+template <typename I>
+concept is_zip_iterator =
+    std::forward_iterator<I> && requires(I &iter) { std::get<0>(*iter); };
+
 } // namespace lib

--- a/include/dr/details/ranges.hpp
+++ b/include/dr/details/ranges.hpp
@@ -71,7 +71,7 @@ struct rank_fn_ {
 
 inline constexpr auto rank = rank_fn_{};
 
-namespace {
+namespace internal {
 
 template <typename R>
 concept remote_range_shadow_impl_ =
@@ -93,7 +93,7 @@ concept has_segments_adl = requires(R &r) {
 
 struct segments_fn_ {
   template <rng::forward_range R>
-    requires(has_segments_method<R> || has_segments_adl<R>)
+    requires(internal::has_segments_method<R> || internal::has_segments_adl<R>)
   constexpr decltype(auto) operator()(R &&r) const {
     if constexpr (has_segments_method<R>) {
       return std::forward<R>(r).segments();
@@ -113,9 +113,9 @@ struct segments_fn_ {
   }
 };
 
-} // namespace
+} // namespace internal
 
-inline constexpr auto segments = segments_fn_{};
+inline constexpr auto segments = internal::segments_fn_{};
 
 namespace {
 

--- a/include/dr/details/ranges.hpp
+++ b/include/dr/details/ranges.hpp
@@ -71,7 +71,7 @@ struct rank_fn_ {
 
 inline constexpr auto rank = rank_fn_{};
 
-namespace internal {
+namespace {
 
 template <typename R>
 concept remote_range_shadow_impl_ =
@@ -93,7 +93,7 @@ concept has_segments_adl = requires(R &r) {
 
 struct segments_fn_ {
   template <rng::forward_range R>
-    requires(internal::has_segments_method<R> || internal::has_segments_adl<R>)
+    requires(has_segments_method<R> || has_segments_adl<R>)
   constexpr decltype(auto) operator()(R &&r) const {
     if constexpr (has_segments_method<R>) {
       return std::forward<R>(r).segments();
@@ -113,9 +113,9 @@ struct segments_fn_ {
   }
 };
 
-} // namespace internal
+} // namespace
 
-inline constexpr auto segments = internal::segments_fn_{};
+inline constexpr auto segments = segments_fn_{};
 
 namespace {
 

--- a/include/dr/details/segments_tools.hpp
+++ b/include/dr/details/segments_tools.hpp
@@ -100,7 +100,6 @@ auto zip_iter_rank(auto zip_iter) {
 
 namespace ranges {
 
-#if 1
 // A standard library range adaptor does not change the rank of a
 // remote range, so we can simply return the rank of the base view.
 template <rng::range V>
@@ -145,7 +144,6 @@ template <rng::range V>
 auto segments_(V &&v) {
   return take_segments(lib::ranges::segments(v.begin()), v.end() - v.begin());
 }
-#endif
 
 template <rng::range V>
   requires(lib::is_zip_view_v<std::remove_cvref_t<V>>)

--- a/include/dr/details/segments_tools.hpp
+++ b/include/dr/details/segments_tools.hpp
@@ -77,7 +77,11 @@ template <typename... Ss> auto zip_segments(Ss &&...iters) {
          rng::views::transform(zip_segment);
 }
 
-auto zip_iter_segments(auto zip_iter) {
+template <typename I>
+concept is_zip_iterator =
+    std::forward_iterator<I> && requires(I &iter) { std::get<0>(*iter); };
+
+auto zip_iter_segments(is_zip_iterator auto zip_iter) {
   // Dereferencing a zip iterator returns a tuple of references, we
   // take the address of the references to iterators, and then get the
   // segments from the iterators.
@@ -90,7 +94,7 @@ auto zip_iter_segments(auto zip_iter) {
   return std::apply(zip, *zip_iter);
 }
 
-auto zip_iter_rank(auto zip_iter) {
+auto zip_iter_rank(is_zip_iterator auto zip_iter) {
   return lib::ranges::rank(std::get<0>(*zip_iter));
 }
 
@@ -151,15 +155,11 @@ auto segments_(V &&zip) {
   return lib::internal::zip_iter_segments(zip.begin());
 }
 
-template <typename I>
-concept is_zip_iterator =
-    std::forward_iterator<I> && requires(I &iter) { std::get<0>(*iter); };
-
-template <is_zip_iterator ZI> auto segments_(ZI zi) {
+template <lib::internal::is_zip_iterator ZI> auto segments_(ZI zi) {
   return lib::internal::zip_iter_segments(zi);
 }
 
-template <is_zip_iterator ZI> auto local_(ZI zi) {
+template <lib::internal::is_zip_iterator ZI> auto local_(ZI zi) {
   auto refs_to_local_zip_iterator = [](auto &&...refs) {
     // Convert the first segment of each component to local and then
     // zip them together, returning the begin() of the zip view

--- a/include/dr/details/segments_tools.hpp
+++ b/include/dr/details/segments_tools.hpp
@@ -151,4 +151,12 @@ auto segments_(V &&zip) {
   return lib::internal::zip_iter_segments(zip.begin());
 }
 
+template <typename I>
+concept is_zip_iterator =
+    std::forward_iterator<I> && requires(I &iter) { std::get<0>(*iter); };
+
+template <is_zip_iterator ZI> auto segments_(ZI zi) {
+  return lib::internal::zip_iter_segments(zi);
+}
+
 } // namespace ranges

--- a/include/dr/details/segments_tools.hpp
+++ b/include/dr/details/segments_tools.hpp
@@ -159,4 +159,15 @@ template <is_zip_iterator ZI> auto segments_(ZI zi) {
   return lib::internal::zip_iter_segments(zi);
 }
 
+template <is_zip_iterator ZI> auto local_(ZI zi) {
+  auto refs_to_local_zip_iterator = [](auto &&...refs) {
+    // Convert the first segment of each component to local and then
+    // zip them together, returning the begin() of the zip view
+    return rng::zip_view(
+               (lib::ranges::local(lib::ranges::segments(&refs)[0]))...)
+        .begin();
+  };
+  return std::apply(refs_to_local_zip_iterator, *zi);
+}
+
 } // namespace ranges

--- a/include/dr/details/segments_tools.hpp
+++ b/include/dr/details/segments_tools.hpp
@@ -117,14 +117,6 @@ template <zip_segment Segment> auto rank_(Segment &&segment) {
   return lib::ranges::rank(&(std::get<0>(segment[0])));
 }
 
-#if 0
-// Did not use this
-template <lib::is_zip_iterator It>
-auto rank_(It &&it) {
-  return lib::ranges::rank(std::get<0>(*it));
-}
-#endif
-
 template <rng::range V>
   requires(lib::is_ref_view_v<std::remove_cvref_t<V>> &&
            lib::distributed_range<decltype(std::declval<V>().base())>)
@@ -156,9 +148,7 @@ auto segments_(V &&v) {
 #endif
 
 template <rng::range V>
-  requires(lib::is_zip_view_v<std::remove_cvref_t<V>>
-           //&& (lib::distributed_iterator<decltype(std::declval<V>().begin())>)
-           )
+  requires(lib::is_zip_view_v<std::remove_cvref_t<V>>)
 auto segments_(V &&zip) {
   return lib::internal::zip_iter_segments(zip.begin());
 }

--- a/include/dr/details/view_detectors.hpp
+++ b/include/dr/details/view_detectors.hpp
@@ -38,4 +38,12 @@ struct is_subrange_view<rng::subrange<T>> : std::true_type {};
 template <typename T>
 inline constexpr bool is_subrange_view_v = is_subrange_view<T>::value;
 
+template <typename... Views> struct is_zip_view : std::false_type {};
+
+template <typename... Views>
+struct is_zip_view<rng::zip_view<Views...>> : std::true_type {};
+
+template <typename... Views>
+inline constexpr bool is_zip_view_v = is_zip_view<Views...>::value;
+
 } // namespace lib

--- a/include/dr/details/view_detectors.hpp
+++ b/include/dr/details/view_detectors.hpp
@@ -38,12 +38,12 @@ struct is_subrange_view<rng::subrange<T>> : std::true_type {};
 template <typename T>
 inline constexpr bool is_subrange_view_v = is_subrange_view<T>::value;
 
-template <typename... Views> struct is_zip_view : std::false_type {};
+template <typename T> struct is_zip_view : std::false_type {};
 
 template <typename... Views>
 struct is_zip_view<rng::zip_view<Views...>> : std::true_type {};
 
-template <typename... Views>
-inline constexpr bool is_zip_view_v = is_zip_view<Views...>::value;
+template <typename T>
+inline constexpr bool is_zip_view_v = is_zip_view<T>::value;
 
 } // namespace lib

--- a/include/dr/mhp.hpp
+++ b/include/dr/mhp.hpp
@@ -41,6 +41,7 @@ namespace rng = ranges;
 #include "concepts/concepts.hpp"
 #include "details/view_detectors.hpp"
 #include "details/segments_tools.hpp"
+#include "mhp/cpos.hpp"
 #include "mhp/containers/distributed_vector.hpp"
 #include "mhp/views.hpp"
 #include "mhp/algorithms/cpu_algorithms.hpp"

--- a/include/dr/mhp/algorithms/cpu_algorithms.hpp
+++ b/include/dr/mhp/algorithms/cpu_algorithms.hpp
@@ -15,7 +15,7 @@ void fill(lib::distributed_contiguous_range auto &&dr, auto value) {
   for (const auto &s : local_segments(dr)) {
     rng::fill(s, value);
   }
-  dr.begin().barrier();
+  mhp::barrier(dr.begin());
 }
 
 /// Collective fill on iterator/sentinel for a distributed range
@@ -37,10 +37,10 @@ void copy(DR_IN &&in, DI_OUT out) {
          rng::views::zip(local_segments(in), local_segments(out))) {
       rng::copy(in_seg, out_seg.begin());
     }
-    out.barrier();
+    mhp::barrier(out);
   } else {
     rng::copy(in, out);
-    out.fence();
+    mhp::fence(out);
   }
 }
 
@@ -66,7 +66,7 @@ void for_each(lib::distributed_range auto &&dr, auto op) {
   for (const auto &s : local_segments(dr)) {
     rng::for_each(s, op);
   }
-  // dr.begin().barrier();
+  mhp::barrier(dr.begin());
 }
 
 //
@@ -81,7 +81,7 @@ void iota(DI first, DI last, auto value) {
   if (first.my_rank() == 0) {
     std::iota(first, last, value);
   }
-  first.fence();
+  mhp::fence(first);
 }
 
 /// Collective iota on distributed range

--- a/include/dr/mhp/algorithms/cpu_algorithms.hpp
+++ b/include/dr/mhp/algorithms/cpu_algorithms.hpp
@@ -66,7 +66,7 @@ void for_each(lib::distributed_range auto &&dr, auto op) {
   for (const auto &s : local_segments(dr)) {
     rng::for_each(s, op);
   }
-  dr.begin().barrier();
+  // dr.begin().barrier();
 }
 
 //

--- a/include/dr/mhp/algorithms/cpu_algorithms.hpp
+++ b/include/dr/mhp/algorithms/cpu_algorithms.hpp
@@ -62,7 +62,7 @@ void for_each(DI first, DI last, auto op) {
 }
 
 /// Collective for_each on distributed range
-void for_each(lib::distributed_contiguous_range auto &&dr, auto op) {
+void for_each(lib::distributed_range auto &&dr, auto op) {
   for (const auto &s : local_segments(dr)) {
     rng::for_each(s, op);
   }

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -68,11 +68,14 @@ public:
   auto local_index(std::size_t index) const { return index % segment_size_; }
 
   T *local(std::size_t index) const {
-    // drlog.debug("index: {} rank(index) {}\n", index, rank(index));
-    if (rank(index) != std::size_t(comm_.rank())) {
-      return nullptr;
+    if (rank(index) == std::size_t(comm_.rank())) {
+      return data_.get() + local_index(index);
+    } else {
+      // If data is not local, return an iterator that cannot be used
+      // to reference data. Caller may check for equality with default
+      // constructor to know if data is local.
+      return T();
     }
-    return data_.get() + local_index(index);
   }
 
   auto rank(std::size_t index) const {

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -71,10 +71,7 @@ public:
     if (rank(index) == std::size_t(comm_.rank())) {
       return data_.get() + local_index(index);
     } else {
-      // If data is not local, return an iterator that cannot be used
-      // to reference data. Caller may check for equality with default
-      // constructor to know if data is local.
-      return T();
+      return nullptr;
     }
   }
 
@@ -259,6 +256,7 @@ public:
   iterator begin() const { return iterator(&storage_, 0); }
   iterator end() const { return iterator(&storage_, storage_.container_size_); }
 
+  void barrier() { storage_.barrier(); }
   void fence() { storage_.fence(); }
 
 private:

--- a/include/dr/mhp/cpos.hpp
+++ b/include/dr/mhp/cpos.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace mhp {
+
+namespace internal {
+
+template <typename Iter>
+concept has_fence_method = requires(Iter i) {
+                             { i.fence() };
+                           };
+
+template <typename Iter>
+concept has_fence_adl = requires(Iter &iter) {
+                          { fence_(iter) };
+                        };
+
+void fence_(lib::internal::is_zip_iterator auto zi) {
+  auto fence = [](auto &&...refs) { (((&refs).fence()), ...); };
+  std::apply(fence, *zi);
+}
+
+struct fence_fn_ {
+  template <std::forward_iterator Iter> void operator()(Iter iter) const {
+    static_assert(has_fence_method<Iter> || has_fence_adl<Iter>);
+    if constexpr (has_fence_method<Iter>) {
+      iter.fence();
+    } else if constexpr (has_fence_adl<Iter>) {
+      fence_(iter);
+    }
+  }
+};
+
+} // namespace internal
+
+inline constexpr auto fence = mhp::internal::fence_fn_{};
+
+namespace internal {
+
+void barrier_(lib::internal::is_zip_iterator auto zi) {
+  auto barrier = [](auto &&...refs) { (((&refs).barrier()), ...); };
+  std::apply(barrier, *zi);
+}
+
+template <typename Iter>
+concept has_barrier_method = requires(Iter i) {
+                               { i.barrier() };
+                             };
+
+template <typename Iter>
+concept has_barrier_adl = requires(Iter &iter) {
+                            { barrier_(iter) };
+                          };
+struct barrier_fn_ {
+  template <std::forward_iterator Iter> void operator()(Iter iter) const {
+    static_assert(has_barrier_method<Iter> || has_barrier_adl<Iter>);
+    if constexpr (has_barrier_method<Iter>) {
+      iter.barrier();
+    } else if constexpr (has_barrier_adl<Iter>) {
+      barrier_(iter);
+    }
+  }
+};
+
+} // namespace internal
+
+inline constexpr auto barrier = mhp::internal::barrier_fn_{};
+
+} // namespace mhp

--- a/include/dr/mhp/views.hpp
+++ b/include/dr/mhp/views.hpp
@@ -9,7 +9,7 @@ namespace mhp {
 auto local_segments(auto &&x) {
   const auto &segments = lib::ranges::segments(x);
   auto is_local = [](const auto &segment) {
-    return segment.begin().local() != nullptr;
+    return lib::ranges::local(segment.begin()) != nullptr;
   };
   auto local_iter = [](auto &&segment) {
     auto b = segment.begin().local();

--- a/include/dr/mhp/views.hpp
+++ b/include/dr/mhp/views.hpp
@@ -9,10 +9,11 @@ namespace mhp {
 auto local_segments(auto &&x) {
   const auto &segments = lib::ranges::segments(x);
   auto is_local = [](const auto &segment) {
-    return lib::ranges::local(segment.begin()) != nullptr;
+    auto local = lib::ranges::local(segment.begin());
+    return local != decltype(local)();
   };
   auto local_iter = [](auto &&segment) {
-    auto b = segment.begin().local();
+    auto b = lib::ranges::local(segment.begin());
     auto size = segment.end() - segment.begin();
     return rng::subrange(b, b + size);
   };

--- a/test/gtest/mhp/mhp-tests.cpp
+++ b/test/gtest/mhp/mhp-tests.cpp
@@ -10,14 +10,6 @@ int comm_size;
 
 cxxopts::ParseResult options;
 
-// Demonstrate some basic assertions.
-TEST(MhpMpiTests, BasicAssertions) {
-  // Expect two strings not to be equal.
-  EXPECT_STRNE("hello", "world");
-  // Expect equality.
-  EXPECT_EQ(7 * 6, 42);
-}
-
 int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
   comm = MPI_COMM_WORLD;

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -46,21 +46,26 @@ TEST(MhpTests, Zip) {
 
 TEST(MhpTests, Take) {
   const int n = 10;
-  V a(n);
   DV dv_a(n);
+  mhp::iota(dv_a, 20);
 
-  auto aview = rng::views::take(a, 2);
   auto dv_aview = rng::views::take(dv_a, 2);
   EXPECT_TRUE(check_segments(dv_aview));
 
-  mhp::iota(dv_a, 20);
   if (comm == 0) {
+    V a(n);
+    auto aview = rng::views::take(a, 2);
     rng::iota(a, 20);
     EXPECT_TRUE(equal(aview, dv_aview));
   }
 
+  dv_a.barrier();
   mhp::for_each(dv_aview, increment{});
+
   if (comm == 0) {
+    V a(n);
+    auto aview = rng::views::take(a, 2);
+    rng::iota(a, 20);
     rng::for_each(aview, increment{});
     EXPECT_TRUE(equal(aview, dv_aview));
   }
@@ -68,21 +73,26 @@ TEST(MhpTests, Take) {
 
 TEST(MhpTests, Drop) {
   const int n = 10;
-  V a(n);
+
   DV dv_a(n);
-
-  auto aview = rng::views::drop(a, 2);
-  auto dv_aview = rng::views::drop(dv_a, 2);
-  EXPECT_TRUE(check_segments(dv_aview));
-
   mhp::iota(dv_a, 20);
+  auto dv_aview = rng::views::drop(dv_a, 2);
+
+  EXPECT_TRUE(check_segments(dv_aview));
   if (comm == 0) {
+    V a(n);
     rng::iota(a, 20);
+    auto aview = rng::views::drop(a, 2);
     EXPECT_TRUE(equal(aview, dv_aview));
   }
 
+  dv_a.barrier();
   mhp::for_each(dv_aview, increment{});
+
   if (comm == 0) {
+    V a(n);
+    rng::iota(a, 20);
+    auto aview = rng::views::drop(a, 2);
     rng::for_each(aview, increment{});
     EXPECT_TRUE(equal(aview, dv_aview));
   }

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -20,48 +20,28 @@ TEST(MhpTests, Subrange) {
   static_assert(lib::distributed_range<decltype(r)>);
 }
 
-auto local_zip_iter(auto remote_iter) {
-  // auto segments = lib::ranges::segments(remote_iter);
-  // auto remote = segments[0];
-  return remote_iter;
-}
-
 TEST(MhpTests, Zip) {
-  // auto x = rng::views::iota(1);
-  // static_assert(lib::distributed_contiguous_range<decltype(x)>);
   DV dv1(10), dv2(10);
   mhp::iota(dv1, 10);
   mhp::iota(dv2, 20);
   auto dzv = rng::views::zip(dv1, dv2);
+  static_assert(lib::is_zip_view_v<decltype(dzv)>);
+  static_assert(lib::distributed_range<decltype(dzv)>);
   EXPECT_TRUE(check_segments(dzv));
   EXPECT_TRUE(check_segments(dzv.begin()));
 
-  fmt::print("dzv: {}\n"
-             "  dv1: {}\n"
-             "  dv2: {}\n"
-             "  segments(dv1): {}\n"
-             "  segments(dv2): {}\n"
-             "  segments(dzv.begin()): {}\n"
-             "  segments(dzv): {}\n",
-             dzv, dv1, dv2, lib::ranges::segments(dv1),
-             lib::ranges::segments(dv2), lib::ranges::segments(dzv.begin()),
-             lib::ranges::segments(dzv));
-  static_assert(lib::is_zip_view_v<decltype(dzv)>);
-  static_assert(lib::distributed_range<decltype(dzv)>);
-  fmt::print("flat: {}\n", rng::join_view(lib::ranges::segments(dzv)));
-  auto local_iter = local_zip_iter(dzv.begin());
-  fmt::print("*dzv.begin(): {}\n"
-             "*local_iter: {}\n",
-             *dzv.begin(), *local_iter);
-#if 1
-  auto incr_0 = [](auto &x) { std::get<0>(x)++; };
-  mhp::for_each(dzv, incr_0);
-  fmt::print("after foreach\n"
-             "dzv: {}\n"
-             "  dv1: {}\n"
-             "  dv2: {}\n",
-             dzv, dv1, dv2);
-#endif
+  auto incr_first = [](auto x) { x.first++; };
+  mhp::for_each(dzv, incr_first);
+
+  if (comm_rank == 0) {
+    V v1(10), v2(10);
+    rng::iota(v1, 10);
+    rng::iota(v2, 20);
+    auto zv = rng::views::zip(v1, v2);
+    rng::for_each(zv, incr_first);
+
+    EXPECT_TRUE(equal(zv, dzv));
+  }
 }
 
 TEST(MhpTests, Take) {

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -30,6 +30,7 @@ TEST(MhpTests, Zip) {
   EXPECT_TRUE(check_segments(dzv));
   EXPECT_TRUE(check_segments(dzv.begin()));
 
+  dv1.barrier();
   auto incr_first = [](auto x) { x.first++; };
   mhp::for_each(dzv, incr_first);
 

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -35,33 +35,17 @@ TEST(MhpTests, Zip) {
              dzv, dv1, dv2, lib::ranges::segments(dv1),
              lib::ranges::segments(dv2));
   static_assert(lib::is_zip_view_v<decltype(dzv)>);
-  static_assert(lib::is_zip_iterator<decltype(dzv.begin())>);
-  static_assert(!lib::is_zip_iterator<int>);
-  //  static_assert(lib::ranges::internal::has_segments_adl<decltype(dzv.begin())>);
-  // static_assert(lib::distributed_iterator<decltype(dzv.begin())>);
-  fmt::print("zip segments: {}\n", ranges::segments_(dzv));
-  // fmt::print("rank seg 0: {}\n",
-  // lib::ranges::rank(ranges::segments_(dzv)[0]));
-  fmt::print("zip segments: {}\n", lib::ranges::segments(dzv));
   static_assert(lib::distributed_range<decltype(dzv)>);
 #if 0
   auto incr_0 = [](auto &x) {
     std::get<0>(x)++;
   };
   mhp::for_each(dzv, incr_0);
-#endif
   fmt::print("after foreach\n"
              "dzv: {}\n"
              "  dv1: {}\n"
              "  dv2: {}\n",
              dzv, dv1, dv2);
-#if 0
-  auto segments = ranges::segments_(dzv);
-  auto segment = segments[0];
-  auto element = segment[0];
-  auto ref = std::get<0>(element);
-  auto it = &ref;
-  auto r = lib::ranges::rank(it);
 #endif
 }
 

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -20,43 +20,6 @@ TEST(MhpTests, Subrange) {
   static_assert(lib::distributed_range<decltype(r)>);
 }
 
-//
-// Zip the segments for 1 or more distributed ranges. e.g.:
-//
-//   segments(dv1): [[10, 11, 12, 13, 14], [15, 16, 17, 18, 19]]
-//   segments(dv2): [[20, 21, 22, 23, 24], [25, 26, 27, 28, 29]]
-//
-//   drop the first 4 elements and zip the segments for the rest
-//
-//    zip segments: [[(14, 24)], [(15, 25), (16, 26), (17, 27), (18, 28), (19,
-//    29)]]
-//
-template <typename... Ss> auto zip_segments(Ss &&...iters) {
-  auto zip_segment = [](auto &&v) {
-    auto zip = [](auto &&...refs) { return rng::views::zip(refs...); };
-    return std::apply(zip, v);
-  };
-
-  return rng::views::zip(lib::ranges::segments(iters)...) |
-         rng::views::transform(zip_segment);
-}
-
-//
-// Given an iter for a zip, return the segmentation
-//
-auto zip_iter_segments(auto zip_iter) {
-  // Dereferencing a zip iterator returns a tuple of references, we
-  // take the address of the references to iterators, and then get the
-  // segments from the iterators.
-
-  // Given the list of refs as arguments, convert to list of iters
-  auto zip = [](auto &&...refs) { return zip_segments(&refs...); };
-
-  // Convert the zip iterator to a tuple of references, and pass the
-  // references as a list of arguments
-  return std::apply(zip, *zip_iter);
-}
-
 TEST(MhpTests, Zip) {
   // auto x = rng::views::iota(1);
   // static_assert(lib::distributed_contiguous_range<decltype(x)>);
@@ -71,7 +34,8 @@ TEST(MhpTests, Zip) {
              "  segments(dv2): {}\n",
              dzv, dv1, dv2, lib::ranges::segments(dv1),
              lib::ranges::segments(dv2));
-  fmt::print("zip segments: {}\n", zip_iter_segments(dzv.begin() + 4));
+  static_assert(lib::is_zip_view_v<dzv>);
+  fmt::print("zip segments: {}\n", ranges::segments_(dzv));
 }
 
 TEST(MhpTests, Take) {

--- a/test/gtest/mhp/views.cpp
+++ b/test/gtest/mhp/views.cpp
@@ -34,8 +34,35 @@ TEST(MhpTests, Zip) {
              "  segments(dv2): {}\n",
              dzv, dv1, dv2, lib::ranges::segments(dv1),
              lib::ranges::segments(dv2));
-  static_assert(lib::is_zip_view_v<dzv>);
+  static_assert(lib::is_zip_view_v<decltype(dzv)>);
+  static_assert(lib::is_zip_iterator<decltype(dzv.begin())>);
+  static_assert(!lib::is_zip_iterator<int>);
+  //  static_assert(lib::ranges::internal::has_segments_adl<decltype(dzv.begin())>);
+  // static_assert(lib::distributed_iterator<decltype(dzv.begin())>);
   fmt::print("zip segments: {}\n", ranges::segments_(dzv));
+  // fmt::print("rank seg 0: {}\n",
+  // lib::ranges::rank(ranges::segments_(dzv)[0]));
+  fmt::print("zip segments: {}\n", lib::ranges::segments(dzv));
+  static_assert(lib::distributed_range<decltype(dzv)>);
+#if 0
+  auto incr_0 = [](auto &x) {
+    std::get<0>(x)++;
+  };
+  mhp::for_each(dzv, incr_0);
+#endif
+  fmt::print("after foreach\n"
+             "dzv: {}\n"
+             "  dv1: {}\n"
+             "  dv2: {}\n",
+             dzv, dv1, dv2);
+#if 0
+  auto segments = ranges::segments_(dzv);
+  auto segment = segments[0];
+  auto element = segment[0];
+  auto ref = std::get<0>(element);
+  auto it = &ref;
+  auto r = lib::ranges::rank(it);
+#endif
 }
 
 TEST(MhpTests, Take) {


### PR DESCRIPTION
Allow parallel algorithms on `zip_view` that contain `distributed_range`. Uses CPO's to provide `segments` and friends. Adding support for `transform_view` should leverage the same code.

I will handle zips that contain iota and misaligned distributed vectors in a separate PR.

@lslusarczyk and @BenBrock: Feedback is welcome.
