### PR TITLE
turn on Wall/Werror for shp and fix issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,12 +127,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
   include(GoogleTest)
 
-  if(ENABLE_SYCL)
-    add_subdirectory(examples/shp)
-    add_subdirectory(test/gtest/shp)
-  endif()
-
-  # shp has warnings, but do for everything else
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wall>)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror>)
 
@@ -141,6 +135,11 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_compile_options(-Wno-tautological-constant-compare)
     # DPL uses deprecated API
     add_compile_options(-Wno-deprecated-declarations)
+  endif()
+
+  if(ENABLE_SYCL)
+    add_subdirectory(examples/shp)
+    add_subdirectory(test/gtest/shp)
   endif()
 
   add_subdirectory(examples/serial)

--- a/examples/shp/test_range.cpp
+++ b/examples/shp/test_range.cpp
@@ -87,11 +87,17 @@ int main(int argc, char **argv) {
 
   auto policy = shp::par_unseq;
 
+  auto r_sub = shp::reduce(policy, subspan, 0.0f, std::plus());
+  printf("r_sub: %f\n", r_sub);
+
   shp::print_range(dspan);
 
   shp::for_each(policy, dspan, [](auto &&elem) { elem = elem + 2; });
 
   shp::print_range(dspan);
+
+  auto r = shp::reduce(policy, dspan, 0.0f, std::plus());
+  printf("r: %f\n", r);
 
   return 0;
 }

--- a/examples/shp/test_range.cpp
+++ b/examples/shp/test_range.cpp
@@ -87,15 +87,11 @@ int main(int argc, char **argv) {
 
   auto policy = shp::par_unseq;
 
-  auto r_sub = shp::reduce(policy, subspan, 0.0f, std::plus());
-
   shp::print_range(dspan);
 
   shp::for_each(policy, dspan, [](auto &&elem) { elem = elem + 2; });
 
   shp::print_range(dspan);
-
-  auto r = shp::reduce(policy, dspan, 0.0f, std::plus());
 
   return 0;
 }

--- a/include/dr/shp/device_span.hpp
+++ b/include/dr/shp/device_span.hpp
@@ -53,16 +53,16 @@ public:
   template <rng::random_access_range R>
     requires(lib::remote_range<R>)
   device_span(R &&r)
-      : rank_(lib::ranges::rank(r)), shp::span<T, Iter>(rng::begin(r),
-                                                        rng::size(r)) {}
+      : shp::span<T, Iter>(rng::begin(r), rng::size(r)),
+        rank_(lib::ranges::rank(r)) {}
 
   template <class It>
   constexpr device_span(It first, std::size_t count, std::size_t rank)
-      : rank_(rank), shp::span<T, Iter>(first, count) {}
+      : shp::span<T, Iter>(first, count), rank_(rank) {}
 
   template <class It, class End>
   constexpr device_span(It first, End last, std::size_t rank)
-      : rank_(rank), shp::span<T, Iter>(first, last) {}
+      : shp::span<T, Iter>(first, last), rank_(rank) {}
 
   constexpr std::size_t rank() const noexcept { return rank_; }
 

--- a/include/dr/shp/device_vector.hpp
+++ b/include/dr/shp/device_vector.hpp
@@ -22,7 +22,7 @@ public:
 
   constexpr device_vector(size_type count, const Allocator &alloc,
                           size_type rank)
-      : rank_(rank), base(count, alloc) {}
+      : base(count, alloc), rank_(rank) {}
 
   constexpr std::size_t rank() const noexcept { return rank_; }
 

--- a/include/dr/shp/distributed_vector.hpp
+++ b/include/dr/shp/distributed_vector.hpp
@@ -60,7 +60,6 @@ public:
     }
 
     if (offset < 0) {
-      difference_type new_idx = difference_type(idx_) + offset;
       size_type new_global_idx = get_global_idx() + offset;
       segment_id_ = new_global_idx / segment_size_;
       idx_ = new_global_idx % segment_size_;

--- a/include/dr/shp/vector.hpp
+++ b/include/dr/shp/vector.hpp
@@ -40,9 +40,8 @@ public:
   explicit vector(size_type count, const Allocator &alloc = Allocator())
       : allocator_(alloc) {
     change_capacity_impl_(count);
-    T value;
     using namespace std;
-    fill(data(), data() + size(), value);
+    fill(data(), data() + size(), T{});
   }
 
   template <std::forward_iterator Iter>

--- a/include/dr/shp/zip_view.hpp
+++ b/include/dr/shp/zip_view.hpp
@@ -137,10 +137,7 @@ public:
     segment_ids.fill(0);
     local_idx.fill(0);
 
-    constexpr std::size_t num_views = sizeof...(Rs);
-
     size_t cumulative_size = 0;
-    size_t segment_id = 0;
 
     using segment_view_type = decltype(get_zipped_view_impl_(
         segment_ids, local_idx, 0, std::make_index_sequence<sizeof...(Rs)>{}));
@@ -177,10 +174,7 @@ public:
     segment_ids.fill(0);
     local_idx.fill(0);
 
-    constexpr std::size_t num_views = sizeof...(Rs);
-
     size_t cumulative_size = 0;
-    size_t segment_id = 0;
 
     using segment_view_type = decltype(get_zipped_segments_impl_(
         segment_ids, local_idx, 0, std::make_index_sequence<sizeof...(Rs)>{}));

--- a/test/gtest/shp/views.cpp
+++ b/test/gtest/shp/views.cpp
@@ -39,14 +39,12 @@ TEST(ShpTests, Zip) {
   rng::iota(dv_a, 100);
   rng::iota(dv_b, 200);
   auto dz = shp::views::zip(dv_a, dv_b, dv_a);
-  auto dz2 = shp::views::zip(dv_a, dv_b);
   auto dzi = shp::views::zip(rng::views::iota(1, 10), dv_b, dv_a);
 
   DV v_a(n), v_b(n);
   rng::iota(v_a, 100);
   rng::iota(v_b, 200);
   auto z = rng::views::zip(v_a, v_b, v_a);
-  auto z2 = rng::views::zip(v_a, v_b);
   auto zi = rng::views::zip(rng::views::iota(1, 10), dv_b, dv_a);
 
   EXPECT_TRUE(equal(z, dz));
@@ -54,6 +52,8 @@ TEST(ShpTests, Zip) {
 
 #if 0
   // zip and dr zip have different value types: tuple/pair
+  auto dz2 = shp::views::zip(dv_a, dv_b);
+  auto z2 = rng::views::zip(v_a, v_b);
   EXPECT_TRUE(equal(z2, dz2));
 #endif
 


### PR DESCRIPTION
Turned on warnings for shp-specific code and fixed issues. You can disable specific warnings this way: https://github.com/oneapi-src/distributed-ranges/blob/8c9852e73518107aaa88d959eef0d2be09fdf53e/CMakeLists.txt#L143

None of the issues were bugs, but they are still worth fixing.

* unused variables
* reference to uninitialized variable
* initializer list order does not match constructor order

```
/nfs/site/home/rscohn1/local/projects/dds/dr/include/./dr/shp/device_span.hpp:56:14: error: field 'rank_' will be initialized afte      base 'shp::span<int, device_ptr<int>>' [-Werror,-Wreorder-ctor]
    :        rank_(lib::ranges::rank(r)),
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
             shp::span<T, Iter>(rng::begin(r), rng::size(r))
```