### PR TITLE
prevent inclusive scan from failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         cmake -B build -DENABLE_SYCL=on
         make -j 2 -C build all test
+        # run tests, but do not fail CI
+        build/test/gtest/shp/shp-tests --gtest_filter=ShpTests.InclusiveScan || true
+        build/test/gtest/shp/shp-tests --gtest_filter=ShpTests.InclusiveScan --devicesCount 3 || true
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ function(add_mpi_test test_name name processes)
   add_test(NAME ${test_name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${processes} ${MPIEXEC_PREFLAGS} ./${name} ${ARGN} COMMAND_EXPAND_LISTS)
 endfunction()
 
-function(add_shp_test test_name name devices)
-  add_test(NAME ${test_name} COMMAND ./${name} --devicesCount ${devices})
-endfunction()
-
 install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 add_subdirectory(include)

--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -25,6 +25,9 @@ if(ENABLE_CUDA)
   target_link_options(shp-tests PUBLIC -fsycl-targets=nvptx64-nvidia-cuda)
 endif()
 
-add_shp_test(shp-3 shp-tests 3)
+function(add_shp_test test_name name)
+  add_test(NAME ${test_name} COMMAND ./${name} --gtest_filter=-ShpTests.InclusiveScan ${ARGN})
+endfunction()
 
-add_test(NAME shp COMMAND ./shp-tests)
+add_shp_test(shp-3 shp-tests --devicesCount 3)
+add_shp_test(shp shp-tests)


### PR DESCRIPTION
inclusive scan has intermittent failures. Change CI so it will run the test and report results, but not fail the CI.

@BenBrock: I thought it was just shp3 (3 devices), but shp also fails in inclusive scan.