### PR TITLE
mhp-sycl for_each

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # -O3 and nan checking
     add_compile_options(-Wno-error=tautological-constant-compare)
     # DPL uses deprecated API
-    add_compile_options(-Wno-error=deprecated-declarations)
+    add_compile_options(-Wno-deprecated-declarations)
     # DPL turns on -fopenmp-simd, triggering optimization warnings in parallel stl
     add_compile_options(-Wno-error=pass-failed)
   endif()

--- a/include/dr/mhp.hpp
+++ b/include/dr/mhp.hpp
@@ -53,10 +53,8 @@ namespace rng = ranges;
 #include "views/transform.hpp"
 
 #include "mhp/global.hpp"
-#ifdef SYCL_LANGUAGE_VERSION
 #include "mhp/sycl_support.hpp"
-#endif
 #include "mhp/containers/distributed_vector.hpp"
 #include "mhp/alignment.hpp"
 #include "mhp/views.hpp"
-#include "mhp/algorithms/cpu_algorithms.hpp"
+#include "mhp/algorithms/algorithms.hpp"

--- a/include/dr/mhp/sycl_support.hpp
+++ b/include/dr/mhp/sycl_support.hpp
@@ -4,11 +4,13 @@
 
 namespace mhp {
 
+#ifdef SYCL_LANGUAGE_VERSION
 namespace _detail {
 
 template <typename T, std::size_t Alignment>
 using shared_base_allocator =
     sycl::usm_allocator<T, sycl::usm::alloc::shared, Alignment>;
+
 }; // namespace _detail
 
 template <typename T, std::size_t Alignment = 0>
@@ -18,5 +20,18 @@ public:
   sycl_shared_allocator(sycl::queue q = sycl_queue())
       : _detail::shared_base_allocator<T, Alignment>(q) {}
 };
+
+struct device_policy {
+  device_policy(sycl::queue q = sycl_queue()) : queue(q), dpl_policy(q) {}
+
+  sycl::queue queue;
+  decltype(oneapi::dpl::execution::make_device_policy(queue)) dpl_policy;
+};
+
+#else // !SYCL_LANGUAGE_VERSION
+
+struct device_policy {};
+
+#endif // SYCL_LANGUAGE_VERSION
 
 } // namespace mhp

--- a/test/gtest/mhp-sycl/CMakeLists.txt
+++ b/test/gtest/mhp-sycl/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_executable(
   mhp-sycl-tests-n
 
+  algorithms.cpp
   distributed_vector.cpp
   mhp-sycl-tests.cpp
 )

--- a/test/gtest/mhp-sycl/algorithms.cpp
+++ b/test/gtest/mhp-sycl/algorithms.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "mhp-sycl-tests.hpp"
+
+using T = int;
+using V = std::vector<T>;
+using A = mhp::sycl_shared_allocator<T>;
+using DV = mhp::distributed_vector<T, A>;
+
+struct negate {
+  void operator()(auto &&v) { v = -v; }
+};
+
+TEST(MhpTests, ForEach) {
+  std::size_t n = 10;
+
+  auto neg = [](auto &v) { v = -v; };
+  DV dv_a(n);
+  mhp::iota(dv_a, 100);
+  mhp::for_each(mhp::device_policy(), dv_a, neg);
+
+  if (comm_rank == 0) {
+    V a(n), a_in(n);
+    rng::iota(a, 100);
+    rng::iota(a_in, 100);
+    rng::for_each(a, negate{});
+    EXPECT_TRUE(unary_check(a_in, a, dv_a));
+  }
+}

--- a/test/gtest/mhp/algorithms.cpp
+++ b/test/gtest/mhp/algorithms.cpp
@@ -54,7 +54,7 @@ TEST(MhpTests, ForEach) {
 
   DV dv_a(n);
   mhp::iota(dv_a, 100);
-  mhp::for_each(dv_a, negate{});
+  mhp::for_each(std::execution::par_unseq, dv_a, negate{});
 
   if (comm_rank == 0) {
     V a(n), a_in(n);


### PR DESCRIPTION
Implement for_each in mhp-sycl

don't emit deprecated warnings. DPL generates so many, it is hard to see real issues.