### PR TITLE
add dr-style and correct errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,12 @@ repos:
 
 - repo: local
   hooks:
+  - id: dr-style
+    name: dr-style
+    entry: python scripts/dr-style.py --Werror include test examples
+    language: system
+    pass_filenames: false
+    always_run: true
   - id: sphinx
     name: sphinx
     entry: make -C doc/spec spelling linkcheck html

--- a/examples/shp/dot_product.cpp
+++ b/examples/shp/dot_product.cpp
@@ -18,7 +18,6 @@ auto dot_product(X &&x, Y &&y) {
 }
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
   auto devices = shp::get_numa_devices(sycl::default_selector_v);
   shp::init(devices);
 

--- a/examples/shp/gemv_example.cpp
+++ b/examples/shp/gemv_example.cpp
@@ -6,7 +6,6 @@
 #include <dr/shp/shp.hpp>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
   auto devices = shp::get_numa_devices(sycl::gpu_selector_v);
   shp::init(devices);
 

--- a/examples/shp/inclusive_scan_example.cpp
+++ b/examples/shp/inclusive_scan_example.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <CL/sycl.hpp>
 #include <dr/shp/shp.hpp>
+#include <sycl/sycl.hpp>
 
 #include <iostream>
 
@@ -11,8 +11,6 @@
 #include <fmt/ranges.h>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
-
   printf("Creating NUMA devices...\n");
   auto devices = shp::get_numa_devices(sycl::default_selector_v);
   shp::init(devices);

--- a/examples/shp/matrix_example.cpp
+++ b/examples/shp/matrix_example.cpp
@@ -5,8 +5,6 @@
 #include <dr/shp/shp.hpp>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
-
   auto devices = shp::get_numa_devices(sycl::gpu_selector_v);
   shp::init(devices);
 

--- a/examples/shp/sparse_test.cpp
+++ b/examples/shp/sparse_test.cpp
@@ -6,7 +6,6 @@
 #include <dr/shp/shp.hpp>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
   auto devices = shp::get_numa_devices(sycl::gpu_selector_v);
   shp::init(devices);
 

--- a/examples/shp/take_example.cpp
+++ b/examples/shp/take_example.cpp
@@ -5,7 +5,6 @@
 #include <dr/shp/shp.hpp>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
   auto devices = shp::get_numa_devices(sycl::gpu_selector_v);
   shp::init(devices);
 

--- a/examples/shp/vector_example.cpp
+++ b/examples/shp/vector_example.cpp
@@ -2,16 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <CL/sycl.hpp>
 #include <dr/shp/shp.hpp>
+#include <sycl/sycl.hpp>
 
 #include <iostream>
 
 template <lib::distributed_iterator Iter> void iter(Iter) {}
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
-
   printf("Creating NUMA devices...\n");
   auto devices = shp::get_numa_devices(sycl::default_selector_v);
   shp::init(devices);

--- a/examples/shp/zip_example.cpp
+++ b/examples/shp/zip_example.cpp
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <CL/sycl.hpp>
 #include <dr/shp/shp.hpp>
+#include <sycl/sycl.hpp>
 
 #include <iostream>
 
 int main(int argc, char **argv) {
-  namespace sycl = cl::sycl;
-
   printf("Creating NUMA devices...\n");
   // auto devices = shp::get_duplicated_devices(sycl::gpu_selector_v, 8);
   auto devices = shp::get_numa_devices(sycl::gpu_selector_v);

--- a/include/dr/shp/algorithms/execution_policy.hpp
+++ b/include/dr/shp/algorithms/execution_policy.hpp
@@ -4,31 +4,31 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <span>
+#include <sycl/sycl.hpp>
 #include <vector>
 
 namespace shp {
 
 struct device_policy {
-  device_policy(cl::sycl::device device) : devices_({device}) {}
-  device_policy(cl::sycl::queue queue) : devices_({queue.get_device()}) {}
+  device_policy(sycl::device device) : devices_({device}) {}
+  device_policy(sycl::queue queue) : devices_({queue.get_device()}) {}
 
-  device_policy() : devices_({cl::sycl::queue{}.get_device()}) {}
+  device_policy() : devices_({sycl::queue{}.get_device()}) {}
 
   template <rng::range R>
-    requires(std::is_same_v<rng::range_value_t<R>, cl::sycl::device>)
+    requires(std::is_same_v<rng::range_value_t<R>, sycl::device>)
   device_policy(R &&devices)
       : devices_(rng::begin(devices), rng::end(devices)) {}
 
-  std::span<cl::sycl::device> get_devices() noexcept { return devices_; }
+  std::span<sycl::device> get_devices() noexcept { return devices_; }
 
-  std::span<const cl::sycl::device> get_devices() const noexcept {
+  std::span<const sycl::device> get_devices() const noexcept {
     return devices_;
   }
 
 private:
-  std::vector<cl::sycl::device> devices_;
+  std::vector<sycl::device> devices_;
 };
 
 } // namespace shp

--- a/include/dr/shp/algorithms/for_each.hpp
+++ b/include/dr/shp/algorithms/for_each.hpp
@@ -4,19 +4,16 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <dr/shp/algorithms/execution_policy.hpp>
 #include <dr/shp/distributed_span.hpp>
 #include <dr/shp/zip_view.hpp>
+#include <sycl/sycl.hpp>
 
 namespace shp {
 
 template <typename ExecutionPolicy, lib::distributed_contiguous_range R,
           typename Fn>
 void for_each(ExecutionPolicy &&policy, R &&r, Fn &&fn) {
-
-  namespace sycl = cl::sycl;
-
   static_assert(
       std::is_same_v<std::remove_cvref_t<ExecutionPolicy>, device_policy>);
 
@@ -36,7 +33,7 @@ void for_each(ExecutionPolicy &&policy, R &&r, Fn &&fn) {
 
       assert(rng::size(segment) > 0);
       auto event = q.parallel_for(rng::size(segment),
-                                  [=](sycl::id<1> idx) { fn(*(begin + idx)); });
+                                  [=](auto idx) { fn(*(begin + idx)); });
       events.emplace_back(event);
       queues.emplace_back(q);
     }
@@ -51,8 +48,6 @@ void for_each(ExecutionPolicy &&policy, R &&r, Fn &&fn) {
 
 template <typename ExecutionPolicy, lib::distributed_range R, typename Fn>
 void for_each(ExecutionPolicy &&policy, R &&r, Fn &&fn) {
-
-  namespace sycl = cl::sycl;
 
   static_assert(
       std::is_same_v<std::remove_cvref_t<ExecutionPolicy>, device_policy>);
@@ -71,8 +66,8 @@ void for_each(ExecutionPolicy &&policy, R &&r, Fn &&fn) {
 
       auto begin = rng::begin(segment);
 
-      auto event = q.parallel_for(sycl::range<1>(rng::size(segment)),
-                                  [=](sycl::id<1> idx) { fn(*(begin + idx)); });
+      auto event = q.parallel_for(rng::size(segment),
+                                  [=](auto idx) { fn(*(begin + idx)); });
       events.emplace_back(event);
       queues.emplace_back(q);
     }

--- a/include/dr/shp/algorithms/gemv.hpp
+++ b/include/dr/shp/algorithms/gemv.hpp
@@ -13,8 +13,6 @@ namespace shp {
 template <lib::distributed_range C, typename T, typename I,
           lib::distributed_range B>
 void gemv(C &&c, shp::sparse_matrix<T, I> &a, B &&b) {
-  namespace sycl = cl::sycl;
-
   assert(c.size() == b.size());
   assert(a.shape()[1] == b.size());
   assert(a.grid_shape()[0] == c.segments().size());
@@ -54,7 +52,7 @@ void gemv(C &&c, shp::sparse_matrix<T, I> &a, B &&b) {
 
     auto event = q.submit([=](auto &&h) {
       h.depends_on(copy_events[i]);
-      h.parallel_for(sycl::range<1>(a_tile.size()), [=](sycl::id<1> idx) {
+      h.parallel_for(a_tile.size(), [=](auto idx) {
         auto &&[index, a_v] = *(a_iter + idx);
         auto &&[i, k] = index;
         auto &&b_v = *(b_iter + k);

--- a/include/dr/shp/algorithms/inclusive_scan.hpp
+++ b/include/dr/shp/algorithms/inclusive_scan.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <oneapi/dpl/execution>
 
@@ -24,8 +24,6 @@ template <typename ExecutionPolicy, lib::distributed_contiguous_range R,
           typename U = rng::range_value_t<R>>
 void inclusive_scan_impl_(ExecutionPolicy &&policy, R &&r, O &&o,
                           BinaryOp &&binary_op, std::optional<U> init = {}) {
-  namespace sycl = cl::sycl;
-
   using T = rng::range_value_t<O>;
 
   static_assert(

--- a/include/dr/shp/algorithms/reduce.hpp
+++ b/include/dr/shp/algorithms/reduce.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <oneapi/dpl/execution>
 
@@ -40,8 +40,6 @@ namespace shp {
 template <typename ExecutionPolicy, lib::distributed_range R, typename T,
           typename BinaryOp>
 T reduce(ExecutionPolicy &&policy, R &&r, T init, BinaryOp &&binary_op) {
-
-  namespace sycl = cl::sycl;
 
   static_assert(
       std::is_same_v<std::remove_cvref_t<ExecutionPolicy>, device_policy>);

--- a/include/dr/shp/allocators.hpp
+++ b/include/dr/shp/allocators.hpp
@@ -5,14 +5,13 @@
 #pragma once
 
 #include "device_ptr.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 namespace shp {
 
 template <typename T>
-using shared_allocator =
-    cl::sycl::usm_allocator<T, cl::sycl::usm::alloc::shared>;
+using shared_allocator = sycl::usm_allocator<T, sycl::usm::alloc::shared>;
 
 template <typename T, std::size_t Alignment = 0>
   requires(std::is_trivially_copyable_v<T>)
@@ -30,10 +29,9 @@ public:
   device_allocator(const device_allocator<U, Alignment> &other) noexcept
       : device_(other.get_device()), context_(other.get_context()) {}
 
-  device_allocator(const cl::sycl::queue &q) noexcept
+  device_allocator(const sycl::queue &q) noexcept
       : device_(q.get_device()), context_(q.get_context()) {}
-  device_allocator(const cl::sycl::context &ctxt,
-                   const sycl::device &dev) noexcept
+  device_allocator(const sycl::context &ctxt, const sycl::device &dev) noexcept
       : device_(dev), context_(ctxt) {}
 
   device_allocator(const device_allocator &) = default;
@@ -44,15 +42,15 @@ public:
 
   pointer allocate(std::size_t size) {
     if constexpr (Alignment == 0) {
-      return pointer(cl::sycl::malloc_device<T>(size, device_, context_));
+      return pointer(sycl::malloc_device<T>(size, device_, context_));
     } else {
-      return pointer(cl::sycl::aligned_alloc_device<T>(Alignment, size, device_,
-                                                       context_));
+      return pointer(
+          sycl::aligned_alloc_device<T>(Alignment, size, device_, context_));
     }
   }
 
   void deallocate(pointer ptr, std::size_t n) {
-    cl::sycl::free(ptr.get_raw_pointer(), context_);
+    sycl::free(ptr.get_raw_pointer(), context_);
   }
 
   bool operator==(const device_allocator &) const = default;
@@ -62,13 +60,13 @@ public:
     using other = device_allocator<U, Alignment>;
   };
 
-  cl::sycl::device get_device() const noexcept { return device_; }
+  sycl::device get_device() const noexcept { return device_; }
 
-  cl::sycl::context get_context() const noexcept { return context_; }
+  sycl::context get_context() const noexcept { return context_; }
 
 private:
-  cl::sycl::device device_;
-  cl::sycl::context context_;
+  sycl::device device_;
+  sycl::context context_;
 };
 
 } // namespace shp

--- a/include/dr/shp/copy.hpp
+++ b/include/dr/shp/copy.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include "device_ptr.hpp"
-#include <CL/sycl.hpp>
 #include <dr/concepts/concepts.hpp>
 #include <dr/details/segments_tools.hpp>
 #include <memory>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 namespace shp {
@@ -26,7 +26,7 @@ template <std::contiguous_iterator InputIt, std::contiguous_iterator OutputIt>
   requires __detail::is_syclmemcopyable<std::iter_value_t<InputIt>,
                                         std::iter_value_t<OutputIt>>
 cl::sycl::event copy_async(InputIt first, InputIt last, OutputIt d_first) {
-  cl::sycl::queue q;
+  sycl::queue q;
   return q.memcpy(std::to_address(d_first), std::to_address(first),
                   sizeof(std::iter_value_t<InputIt>) * (last - first));
 }
@@ -42,7 +42,7 @@ void copy(InputIt first, InputIt last, OutputIt d_first) {
 template <std::contiguous_iterator Iter, typename T>
   requires __detail::is_syclmemcopyable<std::iter_value_t<Iter>, T>
 cl::sycl::event copy_async(Iter first, Iter last, device_ptr<T> d_first) {
-  cl::sycl::queue q;
+  sycl::queue q;
   return q.memcpy(d_first.get_raw_pointer(), std::to_address(first),
                   sizeof(T) * (last - first));
 }
@@ -56,9 +56,8 @@ device_ptr<T> copy(Iter first, Iter last, device_ptr<T> d_first) {
 
 template <typename T, std::contiguous_iterator Iter>
   requires __detail::is_syclmemcopyable<T, std::iter_value_t<Iter>>
-cl::sycl::event copy_async(device_ptr<T> first, device_ptr<T> last,
-                           Iter d_first) {
-  cl::sycl::queue q;
+sycl::event copy_async(device_ptr<T> first, device_ptr<T> last, Iter d_first) {
+  sycl::queue q;
   return q.memcpy(std::to_address(d_first), first.get_raw_pointer(),
                   sizeof(T) * (last - first));
 }
@@ -74,11 +73,11 @@ Iter copy(device_ptr<T> first, device_ptr<T> last, Iter d_first) {
 template <std::forward_iterator InputIt, lib::distributed_iterator OutputIt>
   requires __detail::is_syclmemcopyable<std::iter_value_t<InputIt>,
                                         std::iter_value_t<OutputIt>>
-cl::sycl::event copy_async(InputIt first, InputIt last, OutputIt d_first) {
+sycl::event copy_async(InputIt first, InputIt last, OutputIt d_first) {
   auto segments = lib::ranges::segments(d_first);
   auto segment = std::begin(segments);
 
-  std::vector<cl::sycl::event> events;
+  std::vector<sycl::event> events;
 
   while (first != last) {
     const std::size_t n_to_copy =
@@ -108,11 +107,11 @@ OutputIt copy(InputIt first, InputIt last, OutputIt d_first) {
 template <lib::distributed_iterator InputIt, std::forward_iterator OutputIt>
   requires __detail::is_syclmemcopyable<std::iter_value_t<InputIt>,
                                         std::iter_value_t<OutputIt>>
-cl::sycl::event copy_async(InputIt first, InputIt last, OutputIt d_first) {
+sycl::event copy_async(InputIt first, InputIt last, OutputIt d_first) {
   auto segments =
       lib::internal::take_segments(lib::ranges::segments(first), last - first);
 
-  std::vector<cl::sycl::event> events;
+  std::vector<sycl::event> events;
 
   for (auto &&segment : segments) {
     auto event =
@@ -140,9 +139,9 @@ OutputIt copy(InputIt first, InputIt last, OutputIt d_first) {
 template <std::contiguous_iterator Iter>
   requires(!std::is_const_v<std::iter_value_t<Iter>> &&
            std::is_trivially_copyable_v<std::iter_value_t<Iter>>)
-cl::sycl::event
+sycl::event
     fill_async(Iter first, Iter last, const std::iter_value_t<Iter> &value) {
-  cl::sycl::queue q;
+  sycl::queue q;
   return q.fill(std::to_address(first), value, last - first);
 }
 
@@ -154,9 +153,9 @@ void fill(Iter first, Iter last, const std::iter_value_t<Iter> &value) {
 
 template <typename T>
   requires(!std::is_const_v<T>)
-cl::sycl::event
+sycl::event
     fill_async(device_ptr<T> first, device_ptr<T> last, const T &value) {
-  cl::sycl::queue q;
+  sycl::queue q;
   return q.fill(first.get_raw_pointer(), value, last - first);
 }
 

--- a/include/dr/shp/device_ptr.hpp
+++ b/include/dr/shp/device_ptr.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "device_ref.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 namespace shp {

--- a/include/dr/shp/device_ref.hpp
+++ b/include/dr/shp/device_ref.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 namespace shp {
@@ -24,8 +24,8 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return *pointer_;
 #else
-    // cl::sycl::queue q(shp::context(), sycl::gpu_selector());
-    cl::sycl::queue q;
+    // sycl::queue q(shp::context(), sycl::gpu_selector());
+    sycl::queue q;
     char buffer[sizeof(T)] __attribute__((aligned(sizeof(T))));
     q.memcpy(reinterpret_cast<T *>(buffer), pointer_, sizeof(T)).wait();
     return *reinterpret_cast<T *>(buffer);
@@ -38,8 +38,8 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     *pointer_ = value;
 #else
-    // cl::sycl::queue q(shp::context(), sycl::gpu_selector());
-    cl::sycl::queue q;
+    // sycl::queue q(shp::context(), sycl::gpu_selector());
+    sycl::queue q;
     q.memcpy(pointer_, &value, sizeof(T)).wait();
 #endif
     return *this;

--- a/include/dr/shp/distributed_vector.hpp
+++ b/include/dr/shp/distributed_vector.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <dr/shp/device_ptr.hpp>
 #include <dr/shp/device_vector.hpp>
+#include <sycl/sycl.hpp>
 #include <vector>
 
 #include <dr/details/segments_tools.hpp>
@@ -146,7 +146,7 @@ public:
 
   distributed_vector(std::size_t count, value_type fill_value)
       : distributed_vector(count) {
-    std::vector<cl::sycl::event> events;
+    std::vector<sycl::event> events;
 
     for (auto &&segment : segments_)
       events.push_back(

--- a/include/dr/shp/init.hpp
+++ b/include/dr/shp/init.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <memory>
 #include <span>
+#include <sycl/sycl.hpp>
 #include <type_traits>
 
 #include <dr/shp/algorithms/execution_policy.hpp>
@@ -39,8 +39,8 @@ inline device_policy par_unseq;
 
 template <rng::range R>
 inline void init(R &&devices)
-  requires(std::is_same_v<cl::sycl::device,
-                          std::remove_cvref_t<rng::range_value_t<R>>>)
+  requires(
+      std::is_same_v<sycl::device, std::remove_cvref_t<rng::range_value_t<R>>>)
 {
   internal::devices_.assign(rng::begin(devices), rng::end(devices));
   internal::global_context_ = new sycl::context(internal::devices_);

--- a/test/gtest/shp/shp-tests.hpp
+++ b/test/gtest/shp/shp-tests.hpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include <dr/shp/shp.hpp>
 


### PR DESCRIPTION
Reusing a script I wrote for another project. It does simple pattern match to find style issues.
I updated our includes/namespace to sycl2020. Added to pre-commit

Some of the rules were my personal preference for concise sycl code and could be relaxed.