### PR TITLE
Update fmt git tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ FetchContent_MakeAvailable(range-v3)
 FetchContent_Declare(
   cpp-format
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 9.1.0
+  GIT_TAG 0b0f7cf
 )
 FetchContent_MakeAvailable(cpp-format)
 


### PR DESCRIPTION
I'm hitting this issue when compiling `fmt` with the latest dpcpp: https://github.com/fmtlib/fmt/issues/3005
Updating `fmt` git tag to include the corresponding fix https://github.com/fmtlib/fmt/commit/0b0f7cfbfcebd021c910078003d413354bd843e2
