### PR TITLE
fix fuzzer issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,9 +189,10 @@ exceptions to `spelling_wordlist.txt`. Do not add variable, class,
 function, etc to the exceptions. Spellcheck ignores them if they are
 properly delimited in the source doc.
 
-.. seealso::
+See also
+--------
 
-   `Fuzz Testing`_
+* `Fuzz Testing`_
 
 .. _`Fuzz Testing`: test/fuzz/README.rst
 .. _`Print Type`: https://stackoverflow.com/a/14617848/2525421

--- a/README.rst
+++ b/README.rst
@@ -189,25 +189,11 @@ exceptions to `spelling_wordlist.txt`. Do not add variable, class,
 function, etc to the exceptions. Spellcheck ignores them if they are
 properly delimited in the source doc.
 
-Fuzz Test
----------
+.. seealso::
 
-Build the test::
+   `Fuzz Testing`_
 
-  CXX=clang++ cmake -B build
-  cd build/fuzz/cpu
-  make -j
-  ./cpu-fuzz -max_len=16
-
-The command asserts when it finds an error. Otherwise it runs forever
-so kill it to stop testing. When it finds an error, it writes the
-input to a file in the current directory. To run again for just that
-input::
-
-  ./cpu-fuzz . .
-
-
-
+.. _`Fuzz Testing`: test/fuzz/README.rst
 .. _`Print Type`: https://stackoverflow.com/a/14617848/2525421
 .. _`latest spec`: https://oneapi-src.github.io/distributed-ranges/spec
 .. _`latest doxygen`: https://oneapi-src.github.io/distributed-ranges/doxygen

--- a/test/fuzz/README.rst
+++ b/test/fuzz/README.rst
@@ -1,0 +1,21 @@
+.. SPDX-FileCopyrightText: Intel Corporation
+..
+.. SPDX-License-Identifier: BSD-3-Clause
+
+===========
+ Fuzz Test
+===========
+
+Build the test::
+
+  CXX=clang++ cmake -B build
+  cd build/fuzz/cpu
+  make -j
+  ./cpu-fuzz -max_len=16
+
+The command asserts when it finds an error. Otherwise it runs forever
+so kill it to stop testing. When it finds an error, it writes the
+input to a file in the current directory. To run again for just that
+input::
+
+  ./cpu-fuzz . .

--- a/test/fuzz/cpu/algorithms.cpp
+++ b/test/fuzz/cpu/algorithms.cpp
@@ -13,15 +13,17 @@ void check_transform(std::size_t n, std::size_t b, std::size_t e) {
 
   DV dvi1(n), dvr1(n);
   mhp::iota(dvi1, iota_base);
+  mhp::fill(dvr1, 0);
   mhp::transform(dvi1.begin() + b, dvi1.begin() + e, dvr1.begin(), op);
 
   DV dvi2(n), dvr2(n);
   mhp::iota(dvi2, iota_base);
+  mhp::fill(dvr2, 0);
 
   if (comm_rank == 0) {
     std::transform(dvi2.begin() + b, dvi2.begin() + e, dvr2.begin(), op);
 
-    std::vector<int> v(n), vr(n);
+    std::vector<int> v(n, 0), vr(n, 0);
     rng::iota(v, iota_base);
     std::transform(v.begin() + b, v.begin() + e, vr.begin(), op);
     assert(is_equal(vr, dvr1));
@@ -31,10 +33,15 @@ void check_transform(std::size_t n, std::size_t b, std::size_t e) {
 
 void check_copy(std::size_t n, std::size_t b, std::size_t e) {
 
-  V v_in(n), v(n), v1(n), v2(n);
+  V v_in(n, 0), v(n, 0);
   rng::iota(v_in, 100);
 
   DV dv_in(n), dv1(n), dv2(n), dv3(n);
+  // Need to implement fill constructor!
+  mhp::fill(dv_in, 0);
+  mhp::fill(dv1, 0);
+  mhp::fill(dv2, 0);
+  mhp::fill(dv3, 0);
   mhp::iota(dv_in, 100);
   mhp::copy(dv_in.begin() + b, dv_in.begin() + e, dv1.begin() + b);
   mhp::copy(rng::subrange(dv_in.begin() + b, dv_in.begin() + e),
@@ -50,8 +57,5 @@ void check_copy(std::size_t n, std::size_t b, std::size_t e) {
     assert(is_equal(dv1, v));
     assert(is_equal(dv2, v));
     assert(is_equal(dv3, v));
-
-    assert(is_equal(v1, v));
-    assert(is_equal(v2, v));
   }
 }

--- a/test/fuzz/cpu/cpu-fuzz.hpp
+++ b/test/fuzz/cpu/cpu-fuzz.hpp
@@ -15,9 +15,12 @@ extern int comm_size;
 extern void check_copy(std::size_t n, std::size_t b, std::size_t e);
 extern void check_transform(std::size_t n, std::size_t b, std::size_t e);
 
-bool is_equal(rng::range auto &&r1, rng::range auto &&r2) {
-  for (auto e : rng::zip_view(r1, r2)) {
+bool is_equal(rng::range auto &&expected, rng::range auto &&actual) {
+  for (auto e : rng::zip_view(expected, actual)) {
     if (e.first != e.second) {
+      fmt::print("Expected: {}\n"
+                 "Actual:   {}\n",
+                 expected, actual);
       return false;
     }
   }


### PR DESCRIPTION
The fuzzer was getting random failures. It turns out that it was completely broken, but the way I set up the search space, it was rarely executing any test cases for short runs. I changed the search space so most patterns execute a real test. Fixed issues.

Fixes #71 