### PR TITLE
change communicator size/rank to size_t

### DIFF
--- a/include/dr/details/communicator.hpp
+++ b/include/dr/details/communicator.hpp
@@ -14,8 +14,11 @@ public:
   };
 
   communicator(MPI_Comm comm = MPI_COMM_WORLD) : mpi_comm_(comm) {
-    MPI_Comm_rank(comm, &rank_);
-    MPI_Comm_size(comm, &size_);
+    int rank, size;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    rank_ = rank;
+    size_ = size;
   }
 
   auto size() const { return size_; }
@@ -29,58 +32,62 @@ public:
 
   void barrier() const { MPI_Barrier(mpi_comm_); }
 
-  void bcast(void *src, size_t count, int root) const {
+  void bcast(void *src, std::size_t count, std::size_t root) const {
     MPI_Bcast(src, count, MPI_BYTE, root, mpi_comm_);
   }
 
-  void scatter(const void *src, void *dst, int size, int root) const {
+  void scatter(const void *src, void *dst, std::size_t size,
+               std::size_t root) const {
     MPI_Scatter(src, size, MPI_BYTE, dst, size, MPI_BYTE, root, mpi_comm_);
   }
 
   void scatterv(const void *src, int *counts, int *offsets, void *dst,
-                int dst_count, int root) const {
+                int dst_count, std::size_t root) const {
     assert(counts == nullptr || counts[rank()] == dst_count);
     MPI_Scatterv(src, counts, offsets, MPI_BYTE, dst, dst_count, MPI_BYTE, root,
                  mpi_comm_);
   }
 
-  void gather(const void *src, void *dst, int size, int root) const {
+  void gather(const void *src, void *dst, std::size_t size,
+              std::size_t root) const {
     MPI_Gather(src, size, MPI_BYTE, dst, size, MPI_BYTE, root, mpi_comm_);
   }
 
   template <typename T>
-  void gather(const T &src, std::vector<T> &dst, int root) const {
+  void gather(const T &src, std::vector<T> &dst, std::size_t root) const {
     dst.resize(size());
     MPI_Gather(&src, sizeof(src), MPI_BYTE, dst.data(), sizeof(src), MPI_BYTE,
                root, mpi_comm_);
   }
 
   void gatherv(const void *src, int *counts, int *offsets, void *dst,
-               int root) const {
+               std::size_t root) const {
     MPI_Gatherv(src, counts[rank()], MPI_BYTE, dst, counts, offsets, MPI_BYTE,
                 root, mpi_comm_);
   }
 
   template <typename T>
-  void isend(const T *data, int size, int source, tag t,
+  void isend(const T *data, std::size_t size, std::size_t source, tag t,
              MPI_Request *request) const {
     MPI_Isend(data, size * sizeof(T), MPI_BYTE, source, int(t), mpi_comm_,
               request);
   }
 
   template <rng::contiguous_range R>
-  void isend(const R &data, int source, tag t, MPI_Request *request) const {
+  void isend(const R &data, std::size_t source, tag t,
+             MPI_Request *request) const {
     isend(data.data(), data.size(), source, int(t), request);
   }
 
   template <typename T>
-  void irecv(T *data, int size, int dest, tag t, MPI_Request *request) const {
+  void irecv(T *data, std::size_t size, std::size_t dest, tag t,
+             MPI_Request *request) const {
     MPI_Irecv(data, size * sizeof(T), MPI_BYTE, dest, int(t), mpi_comm_,
               request);
   }
 
   template <rng::contiguous_range R>
-  void irecv(R &data, int source, tag t, MPI_Request *request) const {
+  void irecv(R &data, std::size_t source, tag t, MPI_Request *request) const {
     irecv(data.data(), data.size(), source, int(t), request);
   }
 
@@ -90,13 +97,13 @@ public:
 
 private:
   MPI_Comm mpi_comm_;
-  int rank_;
-  int size_;
+  std::size_t rank_;
+  std::size_t size_;
 };
 
 class rma_window {
 public:
-  void create(communicator comm, void *data, int size) {
+  void create(communicator comm, void *data, std::size_t size) {
     MPI_Win_create(data, size, 1, MPI_INFO_NULL, comm.mpi_comm(), &win_);
   }
 
@@ -112,23 +119,25 @@ public:
   void set_null() { win_ = MPI_WIN_NULL; }
   bool null() const noexcept { return win_ == MPI_WIN_NULL; }
 
-  template <typename T> T get(int rank, int disp) const {
+  template <typename T> T get(std::size_t rank, std::size_t disp) const {
     T dst;
     get(&dst, sizeof(T), rank, disp * sizeof(T));
     return dst;
   }
 
-  void get(void *dst, int size, int rank, int disp) const {
+  void get(void *dst, std::size_t size, std::size_t rank,
+           std::size_t disp) const {
     MPI_Request request;
     MPI_Rget(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
     MPI_Wait(&request, MPI_STATUS_IGNORE);
   }
 
-  void put(const auto &src, int rank, int disp) const {
+  void put(const auto &src, std::size_t rank, std::size_t disp) const {
     put(&src, sizeof(src), rank, disp * sizeof(src));
   }
 
-  void put(const void *src, int size, int rank, int disp) const {
+  void put(const void *src, std::size_t size, std::size_t rank,
+           std::size_t disp) const {
     MPI_Put(src, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_);
   }
 
@@ -137,7 +146,7 @@ public:
     MPI_Win_fence(0, win_);
   }
 
-  void flush(int rank) const {
+  void flush(std::size_t rank) const {
     drlog.debug("flush:: rank: {}\n", rank);
     MPI_Win_flush(rank, win_);
   }

--- a/include/dr/mhp/algorithms/algorithms.hpp
+++ b/include/dr/mhp/algorithms/algorithms.hpp
@@ -122,7 +122,7 @@ void iota(lib::distributed_contiguous_range auto &&r, auto value) {
 
 /// Collective reduction on a distributed range
 template <lib::distributed_iterator DI, typename T>
-T reduce(int root, DI first, DI last, T init, auto &&binary_op) {
+T reduce(std::size_t root, DI first, DI last, T init, auto &&binary_op) {
   T result = 0;
   auto comm = default_comm();
 

--- a/include/dr/mhp/views.hpp
+++ b/include/dr/mhp/views.hpp
@@ -8,7 +8,7 @@ namespace mhp {
 // segment to local
 auto local_segments(auto &&dr) {
   auto is_local = [](const auto &segment) {
-    return lib::ranges::rank(segment) == std::size_t(default_comm().rank());
+    return lib::ranges::rank(segment) == default_comm().rank();
   };
   // Convert from remote iter to local iter
   auto local_iter = [](auto &&segment) {


### PR DESCRIPTION
MPI uses `int` for rank. DR uses `size_t`. Do the conversion in `communicator.hpp` to make DR code more uniform.