### PR TITLE
check for .begin, .end, .size in include directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,9 +52,15 @@ repos:
 
 - repo: local
   hooks:
-  - id: dr-style
-    name: dr-style
+  - id: dr-style-all
+    name: dr-style-all
     entry: python scripts/dr-style.py --Werror include test examples
+    language: system
+    pass_filenames: false
+    always_run: true
+  - id: dr-style-include
+    name: dr-style-include
+    entry: python scripts/dr-style.py --Werror --include include/dr/mhp
     language: system
     pass_filenames: false
     always_run: true

--- a/include/dr/details/remote_subrange.hpp
+++ b/include/dr/details/remote_subrange.hpp
@@ -43,3 +43,8 @@ template <lib::remote_range R>
 remote_subrange(R &&) -> remote_subrange<rng::iterator_t<R>>;
 
 } // namespace lib
+
+// Needed to satisfy concepts for rng::begin
+template <typename R>
+inline constexpr bool rng::enable_borrowed_range<lib::remote_subrange<R>> =
+    true;

--- a/include/dr/mhp/algorithms/algorithms.hpp
+++ b/include/dr/mhp/algorithms/algorithms.hpp
@@ -35,10 +35,10 @@ void fill(DI first, DI last, auto value) {
 
 void copy(lib::distributed_contiguous_range auto &&in,
           lib::distributed_iterator auto out) {
-  if (aligned(in.begin(), out)) {
+  if (aligned(rng::begin(in), out)) {
     for (const auto &&[in_seg, out_seg] :
          rng::views::zip(local_segments(in), local_segments(out))) {
-      rng::copy(in_seg, out_seg.begin());
+      rng::copy(in_seg, rng::begin(out_seg));
     }
     barrier();
   } else {
@@ -67,7 +67,7 @@ void for_each(ExecutionPolicy &&policy, lib::distributed_range auto &&dr,
                                device_policy>) {
     lib::drlog.debug("for_each: dpl execution\n");
     for (const auto &s : local_segments(dr)) {
-      std::for_each(policy.dpl_policy, &*s.begin(), &*s.end(), op);
+      std::for_each(policy.dpl_policy, &*rng::begin(s), &*rng::end(s), op);
     }
   } else {
     lib::drlog.debug("for_each: parallel cpu execution\n");
@@ -111,7 +111,7 @@ void iota(DI first, DI last, auto value) {
 
 /// Collective iota on distributed range
 void iota(lib::distributed_contiguous_range auto &&r, auto value) {
-  mhp::iota(r.begin(), r.end(), value);
+  mhp::iota(rng::begin(r), rng::end(r), value);
 }
 
 //
@@ -122,10 +122,10 @@ void iota(lib::distributed_contiguous_range auto &&r, auto value) {
 
 void transform(lib::distributed_range auto &&in,
                lib::distributed_iterator auto out, auto op) {
-  if (aligned(in.begin(), out)) {
+  if (aligned(rng::begin(in), out)) {
     for (const auto &&[in_seg, out_seg] :
          rng::views::zip(local_segments(in), local_segments(out))) {
-      rng::transform(in_seg, out_seg.begin(), op);
+      rng::transform(in_seg, rng::begin(out_seg), op);
     }
     barrier();
   } else {

--- a/include/dr/mhp/alignment.hpp
+++ b/include/dr/mhp/alignment.hpp
@@ -19,7 +19,7 @@ bool aligned(lib::distributed_iterator auto iter1,
     return false;
   for (auto seg : combined) {
     if (lib::ranges::rank(seg.first) != lib::ranges::rank(seg.second) ||
-        seg.first.size() != seg.second.size()) {
+        rng::distance(seg.first) != rng::distance(seg.second)) {
       return false;
     }
   }

--- a/include/dr/mhp/views.hpp
+++ b/include/dr/mhp/views.hpp
@@ -12,9 +12,8 @@ auto local_segments(auto &&dr) {
   };
   // Convert from remote iter to local iter
   auto local_iter = [](auto &&segment) {
-    auto b = lib::ranges::local(segment.begin());
-    auto size = segment.end() - segment.begin();
-    return rng::subrange(b, b + size);
+    auto b = lib::ranges::local(rng::begin(segment));
+    return rng::subrange(b, b + rng::distance(segment));
   };
   return lib::ranges::segments(dr) | rng::views::filter(is_local) |
          rng::views::transform(local_iter);

--- a/scripts/dr-style.py
+++ b/scripts/dr-style.py
@@ -74,6 +74,18 @@ include_rules = [
         r'\.size()',
         'use rng::distance()',
     ),
+    (
+        r'std::begin\(',
+        'use rng::begin()',
+    ),
+    (
+        r'std::end\(',
+        'use rng::end()',
+    ),
+    (
+        r'std::distance\(',
+        'use rng::distance()',
+    ),
 ]
 include_rules_compiled = []
 

--- a/scripts/dr-style.py
+++ b/scripts/dr-style.py
@@ -20,7 +20,9 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 logger.propagate = False
 
-positives = [
+exclude_rule = re.compile('dr-style ignore')
+
+all_rules = [
     (
         r'using namespace sycl|using namespace cl::sycl',
         'eliminate using',
@@ -57,7 +59,23 @@ positives = [
     ),
 ]
 
-compiled_positives = []
+all_rules_compiled = []
+
+include_rules = [
+    (
+        r'\.begin()',
+        'use rng::begin()',
+    ),
+    (
+        r'\.end()',
+        'use rng::end()',
+    ),
+    (
+        r'\.size()',
+        'use rng::distance()',
+    ),
+]
+include_rules_compiled = []
 
 
 def parse_args():
@@ -72,7 +90,10 @@ def parse_args():
         '--Werror', action='store_true', help='treat warnings as errors'
     )
     parser.add_argument(
-        '--verbose', action='store_true', help='emit informational messages'
+        '--verbose', action='store_true', help='debugging output'
+    )
+    parser.add_argument(
+        '--include', action='store_true', help='use include directory rules'
     )
     return parser.parse_args()
 
@@ -81,17 +102,18 @@ def warning(warning, file, line, message):
     global errors
     if args.Werror:
         errors += 1
-    logger.warning('%s:%d: warning: %s: %s' % (file, line, warning, message))
+    logger.warning(f'{file}:{line}: warning: {warning}: {message}')
 
 
 def check_file(path):
-    logging.info('Checking %s' % path)
+    logging.info(f'Checking {path}')
+    rules = include_rules_compiled if args.include else all_rules_compiled
     lineno = 1
     with open(path) as fin:
         for line in fin.readlines():
-            for check in compiled_positives:
-                if check[0].search(line):
-                    warning(check[1], path, lineno, line.rstrip())
+            for rule in rules:
+                if rule[0].search(line) and not exclude_rule.search(line):
+                    warning(rule[1], path, lineno, line.rstrip())
             lineno += 1
 
 
@@ -102,9 +124,12 @@ def check_files():
 
 
 def compile_checks():
-    global compiled_positives
-    compiled_positives = [
-        (re.compile(check[0]), check[1]) for check in positives
+    global all_rules_compiled, include_rules_compiled
+    all_rules_compiled = [
+        (re.compile(check[0]), check[1]) for check in all_rules
+    ]
+    include_rules_compiled = [
+        (re.compile(check[0]), check[1]) for check in include_rules
     ]
 
 
@@ -112,7 +137,7 @@ def main():
     global args
     args = parse_args()
     if args.verbose:
-        ch.setLevel(logging.INFO)
+        logging.basicConfig(level=logging.INFO)
     compile_checks()
     check_files()
     print(f'Errors: {errors}')


### PR DESCRIPTION
@BenBrock: I extended the checker to look for `.begin()`, `.end()`, `.size()` in the include directory.  It suggests using `rng::begin`, `rng::end`, `rng::distance`. You can also allow by adding `// dr-style ignore` to the line. For now, I only turned it on in mhp.

The only surprise was having to enable borrowed range for `remote_subrange`, but I think that is correct. You can see that below.

There are cases when `.begin()` is correct, but I think it is better to default to `rng::begin` in our code. Does this look ok? I intend to do the rest of the include directory, but not examples/tests.