### PR TITLE
turn off -g for Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
   set(CMAKE_C_FLAGS_DEBUG "-O0 -g -ggdb")
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -ggdb")
-  set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g")
+  set(CMAKE_C_FLAGS_RELEASE "-O3")
+  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
   #
   # Common dependencies for examples


### PR DESCRIPTION
Debug info is 100Mbytes for mhp-tests. This speeds up build, but it is still slow.