### PR TITLE
AOS support

### DIFF
--- a/include/dr/mhp/algorithms/algorithms.hpp
+++ b/include/dr/mhp/algorithms/algorithms.hpp
@@ -12,11 +12,8 @@ namespace mhp {
 
 /// Collective fill on distributed range
 void fill(lib::distributed_contiguous_range auto &&dr, auto value) {
-  lib::drlog.debug("fill: dr: {}\n", dr);
   for (const auto &s : local_segments(dr)) {
-    lib::drlog.debug("fill: segment before: {}\n", s);
     rng::fill(s, value);
-    lib::drlog.debug("fill: segment after: {}\n", s);
   }
   barrier();
 }

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -109,15 +109,13 @@ public:
     auto segment_offset = index_ + dv_->halo_bounds_.prev;
     auto value =
         dv_->win_.template get<value_type>(segment_index_, segment_offset);
-    lib::drlog.debug("get {} =  ({}:{})\n", value, segment_index_,
-                     segment_offset);
+    lib::drlog.debug("get ({}:{})\n", segment_index_, segment_offset);
     return value;
   }
 
   void put(const value_type &value) const {
     auto segment_offset = index_ + dv_->halo_bounds_.prev;
-    lib::drlog.debug("put ({}:{}) = {}\n", segment_index_, segment_offset,
-                     value);
+    lib::drlog.debug("put ({}:{})\n", segment_index_, segment_offset);
     dv_->win_.put(value, segment_index_, segment_offset);
   }
 
@@ -224,7 +222,21 @@ public:
   auto operator[](difference_type n) const { return *(begin() + n); }
   auto &halo() { return *halo_; }
 
-  auto operator==(const std::vector<T> &local) const { return false; }
+#if 0
+  auto operator==(const std::vector<T> &local) const {
+    if (size() == rng::size(local)) {
+      return false;
+    }
+
+    for (std::size_t i = 0; i < size(); i++) {
+      if (T((*this)[i]) != T(local[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+#endif
 
 private:
   void init(auto size, auto hb, auto allocator) {
@@ -275,23 +287,6 @@ auto &halo(has_halo_method auto &&dr) {
 }
 
 } // namespace mhp
-
-template <typename T, typename Alloc>
-std::ostream &operator<<(std::ostream &os,
-                         const mhp::distributed_vector<T, Alloc> &dist) {
-  os << "{ ";
-  bool first = true;
-  for (const auto &val : dist) {
-    if (first) {
-      first = false;
-    } else {
-      os << ", ";
-    }
-    os << val;
-  }
-  os << " }";
-  return os;
-}
 
 #if !defined(DR_SPEC)
 

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -224,6 +224,8 @@ public:
   auto operator[](difference_type n) const { return *(begin() + n); }
   auto &halo() { return *halo_; }
 
+  auto operator==(const std::vector<T> &local) const { return false; }
+
 private:
   void init(auto size, auto hb, auto allocator) {
     allocator_ = allocator;
@@ -273,6 +275,23 @@ auto &halo(has_halo_method auto &&dr) {
 }
 
 } // namespace mhp
+
+template <typename T, typename Alloc>
+std::ostream &operator<<(std::ostream &os,
+                         const mhp::distributed_vector<T, Alloc> &dist) {
+  os << "{ ";
+  bool first = true;
+  for (const auto &val : dist) {
+    if (first) {
+      first = false;
+    } else {
+      os << ", ";
+    }
+    os << val;
+  }
+  os << " }";
+  return os;
+}
 
 #if !defined(DR_SPEC)
 

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -222,22 +222,6 @@ public:
   auto operator[](difference_type n) const { return *(begin() + n); }
   auto &halo() { return *halo_; }
 
-#if 0
-  auto operator==(const std::vector<T> &local) const {
-    if (size() == rng::size(local)) {
-      return false;
-    }
-
-    for (std::size_t i = 0; i < size(); i++) {
-      if (T((*this)[i]) != T(local[i])) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-#endif
-
 private:
   void init(auto size, auto hb, auto allocator) {
     allocator_ = allocator;

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -75,13 +75,14 @@ template <typename T> struct Ops3 {
 };
 
 template <rng::range R1, rng::range R2> bool is_equal(R1 &&r1, R2 &&r2) {
-  using T = typename std::remove_cvref_t<R1>::value_type;
   if (rng::distance(rng::begin(r1), rng::end(r1)) !=
       rng::distance(rng::begin(r2), rng::end(r2))) {
     return false;
   }
   for (auto e : rng::zip_view(r1, r2)) {
-    if (T(e.first) != T(e.second)) {
+    auto v1 = e.first;
+    auto v2 = e.second;
+    if (v1 != v2) {
       return false;
     }
   }

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -295,7 +295,7 @@ std::ostream &operator<<(std::ostream &os,
 }
 
 template <typename T, typename Allocator>
-auto operator==(const xhp::distributed_vector<T, Allocator> &dist_vec,
+bool operator==(const xhp::distributed_vector<T, Allocator> &dist_vec,
                 const std::vector<T> &local_vec) {
   return is_equal(dist_vec, local_vec);
 }

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -6,21 +6,22 @@
 template <lib::distributed_range DR>
 using LocalVec = std::vector<typename DR::value_type>;
 
+struct AOS_Struct {
+  bool operator==(const AOS_Struct &other) const {
+    return first == other.first && second == other.second;
+  }
+
+  int first, second;
+};
+
 struct OpsAOS {
-  struct Struct {
-    bool operator==(const Struct &other) const {
-      return first == other.first && second == other.second;
-    }
 
-    int first, second;
-  };
-
-  using dist_vec_type = xhp::distributed_vector<Struct>;
-  using vec_type = std::vector<Struct>;
+  using dist_vec_type = xhp::distributed_vector<AOS_Struct>;
+  using vec_type = std::vector<AOS_Struct>;
 
   OpsAOS(std::size_t n) : dist_vec(n), vec(n) {
     for (std::size_t i = 0; i < n; i++) {
-      Struct s{100 + int(i), 200 + int(i)};
+      AOS_Struct s{100 + int(i), 200 + int(i)};
       dist_vec[i] = s;
       vec[i] = s;
     }
@@ -31,8 +32,7 @@ struct OpsAOS {
   vec_type vec;
 };
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const typename OpsAOS::Struct &st) {
+inline std::ostream &operator<<(std::ostream &os, const AOS_Struct &st) {
   os << "[ " << st.first << " " << st.second << " ]";
   return os;
 }

--- a/test/gtest/include/common/distributed_vector.hpp
+++ b/test/gtest/include/common/distributed_vector.hpp
@@ -63,7 +63,7 @@ TEST(DistributedVector, ConstructorBasicAOS) {
 }
 
 TEST(DistributedVector, ConstructorFillAOS) {
-  OpsAOS::Struct fill_value{1, 2};
+  AOS_Struct fill_value{1, 2};
   OpsAOS::dist_vec_type dist_vec(10, fill_value);
   OpsAOS::vec_type local_vec(10, fill_value);
 

--- a/test/gtest/include/common/distributed_vector.hpp
+++ b/test/gtest/include/common/distributed_vector.hpp
@@ -24,17 +24,19 @@ TYPED_TEST(DistributedVectorTestTypes, Requirements) {
   static_assert(lib::distributed_contiguous_range<decltype(dv)>);
 }
 
-// For testing infrastructure
+// gtest support
 TYPED_TEST(DistributedVectorTestTypes, Stream) {
   Ops1<TypeParam> ops(10);
   std::cout << ops.dist_vec << "\n";
 }
 
+// gtest support
 TYPED_TEST(DistributedVectorTestTypes, Equality) {
   Ops1<TypeParam> ops(10);
   iota(ops.dist_vec, 100);
   rng::iota(ops.vec, 100);
-  EXPECT_EQ(ops.dist_vec, ops.vec);
+  EXPECT_TRUE(ops.dist_vec == ops.vec);
+  EXPECT_EQ(ops.vec, ops.dist_vec);
 }
 
 TEST(DistributedVector, ConstructorBasic) {
@@ -44,17 +46,26 @@ TEST(DistributedVector, ConstructorBasic) {
   std::vector<int> local_vec(10);
   rng::iota(local_vec, 100);
 
-  // local_vec == dist_vec;
-  // EXPECT_EQ(local_vec, dist_vec);
+  EXPECT_EQ(local_vec, dist_vec);
 }
 
-#if 0
 TEST(DistributedVector, ConstructorFill) {
   xhp::distributed_vector<int> dist_vec(10, 1);
 
   std::vector<int> local_vec(10, 1);
 
-  //EXPECT_EQ(local_vec, dist_vec);
+  EXPECT_EQ(local_vec, dist_vec);
 }
 
-#endif
+TEST(DistributedVector, ConstructorBasicAOS) {
+  OpsAOS ops(10);
+  EXPECT_EQ(ops.vec, ops.dist_vec);
+}
+
+TEST(DistributedVector, ConstructorFillAOS) {
+  OpsAOS::Struct fill_value{1, 2};
+  OpsAOS::dist_vec_type dist_vec(10, fill_value);
+  OpsAOS::vec_type local_vec(10, fill_value);
+
+  EXPECT_EQ(local_vec, dist_vec);
+}

--- a/test/gtest/include/common/distributed_vector.hpp
+++ b/test/gtest/include/common/distributed_vector.hpp
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // Fixture
-template <typename T> class DistributedVector : public testing::Test {
+template <typename T> class DistributedVectorTestTypes : public testing::Test {
 public:
 };
 
-TYPED_TEST_SUITE(DistributedVector, TestTypes);
+TYPED_TEST_SUITE(DistributedVectorTestTypes, TestTypes);
 
-TYPED_TEST(DistributedVector, Requirements) {
+TYPED_TEST(DistributedVectorTestTypes, Requirements) {
   TypeParam dv(10);
 
   static_assert(rng::random_access_range<decltype(dv.segments())>);
@@ -24,13 +24,37 @@ TYPED_TEST(DistributedVector, Requirements) {
   static_assert(lib::distributed_contiguous_range<decltype(dv)>);
 }
 
-TYPED_TEST(DistributedVector, Constructors) {
-  TypeParam a1(10);
-  iota(a1, 10);
-
-  TypeParam a3(10, 2);
-  if (comm_rank == 0) {
-    LocalVec<TypeParam> v3(10, 2);
-    EXPECT_TRUE(equal(a3, v3));
-  }
+// For testing infrastructure
+TYPED_TEST(DistributedVectorTestTypes, Stream) {
+  Ops1<TypeParam> ops(10);
+  std::cout << ops.dist_vec << "\n";
 }
+
+TYPED_TEST(DistributedVectorTestTypes, Equality) {
+  Ops1<TypeParam> ops(10);
+  iota(ops.dist_vec, 100);
+  rng::iota(ops.vec, 100);
+  EXPECT_EQ(ops.dist_vec, ops.vec);
+}
+
+TEST(DistributedVector, ConstructorBasic) {
+  xhp::distributed_vector<int> dist_vec(10);
+  iota(dist_vec, 100);
+
+  std::vector<int> local_vec(10);
+  rng::iota(local_vec, 100);
+
+  // local_vec == dist_vec;
+  // EXPECT_EQ(local_vec, dist_vec);
+}
+
+#if 0
+TEST(DistributedVector, ConstructorFill) {
+  xhp::distributed_vector<int> dist_vec(10, 1);
+
+  std::vector<int> local_vec(10, 1);
+
+  //EXPECT_EQ(local_vec, dist_vec);
+}
+
+#endif

--- a/test/gtest/mhp/mhp-tests.cpp
+++ b/test/gtest/mhp/mhp-tests.cpp
@@ -5,11 +5,11 @@
 #include "mhp-tests.hpp"
 
 // Use this for shorter build time
-// #define MINIMAL_TEST 1
+#define MINIMAL_TEST 1
 #ifdef MINIMAL_TEST
 
 using TestTypes = ::testing::Types<mhp::distributed_vector<int>>;
-#include "common/zip.hpp"
+#include "common/distributed_vector.hpp"
 
 #else
 

--- a/test/gtest/mhp/mhp-tests.cpp
+++ b/test/gtest/mhp/mhp-tests.cpp
@@ -5,7 +5,7 @@
 #include "mhp-tests.hpp"
 
 // Use this for shorter build time
-#define MINIMAL_TEST 1
+// #define MINIMAL_TEST 1
 #ifdef MINIMAL_TEST
 
 using TestTypes = ::testing::Types<mhp::distributed_vector<int>>;

--- a/test/gtest/shp/shp-tests.cpp
+++ b/test/gtest/shp/shp-tests.cpp
@@ -7,7 +7,8 @@
 using TestTypes = ::testing::Types<shp::distributed_vector<int>,
                                    shp::distributed_vector<float>>;
 
-#include "common/distributed_vector.hpp"
+// AOS issues
+// #include "common/distributed_vector.hpp"
 #include "common/drop.hpp"
 // Not implemented???
 // #include "common/fill.hpp"

--- a/test/gtest/shp/shp-tests.cpp
+++ b/test/gtest/shp/shp-tests.cpp
@@ -7,8 +7,7 @@
 using TestTypes = ::testing::Types<shp::distributed_vector<int>,
                                    shp::distributed_vector<float>>;
 
-// AOS issues
-// #include "common/distributed_vector.hpp"
+#include "common/distributed_vector.hpp"
 #include "common/drop.hpp"
 // Not implemented???
 // #include "common/fill.hpp"


### PR DESCRIPTION
Support distributed vectors that are structure/class instead of built-in types. For MHP, there were problems where logging code assumed fmt knows how to print a value.

Tests are common, but SHP is disabled. It looks like sycl fill does not work.

Enabled `EXPECT_EQ` on distributed vectors. You need to define `operator==` and `operator<<`.  When they are free functions, they need to be defined in the same namespace as the class. It gets a little messy because the definitions are specific to the testing code.