### PR TITLE
zip sycl for_each

### DIFF
--- a/test/gtest/include/common/zip.hpp
+++ b/test/gtest/include/common/zip.hpp
@@ -25,8 +25,8 @@ TYPED_TEST(Zip, Zip3) {
 }
 
 auto zip_inner(auto &&r1, auto &&r2) {
-  return rng::views::zip(rng::subrange(r1.begin() + 1, r1.end() - 1),
-                         rng::subrange(r2.begin() + 1, r2.end() - 1));
+  return zhp::zip(rng::subrange(r1.begin() + 1, r1.end() - 1),
+                  rng::subrange(r2.begin() + 1, r2.end() - 1));
 }
 
 TYPED_TEST(Zip, Subrange) {
@@ -41,7 +41,7 @@ TYPED_TEST(Zip, ForEach) {
 
   auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };
   xhp::for_each(default_policy(ops.dist_vec0),
-                rng::views::zip(ops.dist_vec0, ops.dist_vec1), copy);
+                zhp::zip(ops.dist_vec0, ops.dist_vec1), copy);
   rng::for_each(rng::views::zip(ops.vec0, ops.vec1), copy);
 
   EXPECT_EQ(ops.vec0, ops.dist_vec0);

--- a/test/gtest/include/common/zip.hpp
+++ b/test/gtest/include/common/zip.hpp
@@ -35,3 +35,15 @@ TYPED_TEST(Zip, Subrange) {
   EXPECT_TRUE(check_view(zip_inner(ops.vec0, ops.vec1),
                          zip_inner(ops.dist_vec0, ops.dist_vec1)));
 }
+
+TYPED_TEST(Zip, ForEach) {
+  Ops2<TypeParam> ops(10);
+
+  auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };
+  xhp::for_each(default_policy(ops.dist_vec0),
+                rng::views::zip(ops.dist_vec0, ops.dist_vec1), copy);
+  rng::for_each(rng::views::zip(ops.vec0, ops.vec1), copy);
+
+  EXPECT_EQ(ops.vec0, ops.dist_vec0);
+  EXPECT_EQ(ops.vec1, ops.dist_vec1);
+}


### PR DESCRIPTION
Test sycl zip for_each. MHP is broken because we use DPL for_each, and try to convert the iterators to raw pointers, but a zip has no raw ponter. SHP is not tested because of the tuple/pair mismatch.

Relates to #82