### PR TITLE
fix ci issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@
 repos:
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v15.0.7
+  rev: v16.0.0
   hooks:
    - id: clang-format
 
 - repo: https://github.com/ambv/black
-  rev: 23.1.0
+  rev: 23.3.0
   hooks:
   - id: black
 

--- a/include/dr/concepts/concepts.hpp
+++ b/include/dr/concepts/concepts.hpp
@@ -23,21 +23,18 @@ concept distributed_range =
 template <typename I>
 concept remote_contiguous_iterator =
     std::random_access_iterator<I> && requires(I &iter) {
-                                        lib::ranges::rank(iter);
-                                        {
-                                          lib::ranges::local(iter)
-                                          } -> std::contiguous_iterator;
-                                      };
+      lib::ranges::rank(iter);
+      { lib::ranges::local(iter) } -> std::contiguous_iterator;
+    };
 
 template <typename I>
-concept distributed_iterator =
-    std::forward_iterator<I> &&
-    requires(I &iter) { lib::ranges::segments(iter); };
+concept distributed_iterator = std::forward_iterator<I> && requires(I &iter) {
+  lib::ranges::segments(iter);
+};
 
 template <typename R>
 concept remote_contiguous_range =
-    remote_range<R> && rng::random_access_range<R> &&
-    requires(R &r) {
+    remote_range<R> && rng::random_access_range<R> && requires(R &r) {
       { lib::ranges::local(r) } -> rng::contiguous_range;
     };
 

--- a/include/dr/details/iterator_adaptor.hpp
+++ b/include/dr/details/iterator_adaptor.hpp
@@ -10,8 +10,8 @@ namespace {
 
 template <typename R>
 concept has_segments_method = requires(R r) {
-                                { r.segments() };
-                              };
+  { r.segments() };
+};
 
 } // namespace
 

--- a/include/dr/details/ranges.hpp
+++ b/include/dr/details/ranges.hpp
@@ -18,18 +18,18 @@ namespace {
 
 template <typename T>
 concept has_rank_method = requires(T t) {
-                            { t.rank() } -> std::weakly_incrementable;
-                          };
+  { t.rank() } -> std::weakly_incrementable;
+};
 
 template <typename R>
 concept has_rank_adl = requires(R &r) {
-                         { rank_(r) } -> std::weakly_incrementable;
-                       };
+  { rank_(r) } -> std::weakly_incrementable;
+};
 
 template <typename Iter>
 concept is_remote_iterator_shadow_impl_ =
-    std::forward_iterator<Iter> && has_rank_method<Iter> && !
-disable_rank<std::remove_cv_t<Iter>>;
+    std::forward_iterator<Iter> && has_rank_method<Iter> &&
+    !disable_rank<std::remove_cv_t<Iter>>;
 
 } // namespace
 
@@ -83,13 +83,13 @@ concept segments_range =
 
 template <typename R>
 concept has_segments_method = requires(R r) {
-                                { r.segments() } -> segments_range;
-                              };
+  { r.segments() } -> segments_range;
+};
 
 template <typename R>
 concept has_segments_adl = requires(R &r) {
-                             { segments_(r) } -> segments_range;
-                           };
+  { segments_(r) } -> segments_range;
+};
 
 struct segments_fn_ {
   template <rng::forward_range R>
@@ -121,14 +121,13 @@ namespace {
 
 template <typename Iter>
 concept has_local_adl = requires(Iter &iter) {
-                          { local_(iter) } -> std::forward_iterator;
-                        };
+  { local_(iter) } -> std::forward_iterator;
+};
 
 template <typename Iter>
-concept has_local_method =
-    std::forward_iterator<Iter> && requires(Iter i) {
-                                     { i.local() } -> std::forward_iterator;
-                                   };
+concept has_local_method = std::forward_iterator<Iter> && requires(Iter i) {
+  { i.local() } -> std::forward_iterator;
+};
 
 struct local_fn_ {
 

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -261,10 +261,9 @@ private:
 };
 
 template <typename DR>
-concept has_halo_method = lib::distributed_range<DR> &&
-                          requires(DR &&dr) {
-                            { rng::begin(lib::ranges::segments(dr)[0]).halo() };
-                          };
+concept has_halo_method = lib::distributed_range<DR> && requires(DR &&dr) {
+  { rng::begin(lib::ranges::segments(dr)[0]).halo() };
+};
 
 auto &halo(has_halo_method auto &&dr) {
   return rng::begin(lib::ranges::segments(dr)[0]).halo();

--- a/include/dr/shp/algorithms/copy.hpp
+++ b/include/dr/shp/algorithms/copy.hpp
@@ -75,9 +75,9 @@ Iter copy(device_ptr<T> first, device_ptr<T> last, Iter d_first) {
 // Copy from device to device
 template <typename T>
   requires(!std::is_const_v<T> && std::is_trivially_copyable_v<T>)
-sycl::event
-    copy_async(device_ptr<std::add_const_t<T>> first,
-               device_ptr<std::add_const_t<T>> last, device_ptr<T> d_first) {
+sycl::event copy_async(device_ptr<std::add_const_t<T>> first,
+                       device_ptr<std::add_const_t<T>> last,
+                       device_ptr<T> d_first) {
   auto q = shp::__detail::default_queue();
   return q.memcpy(d_first.get_raw_pointer(), first.get_raw_pointer(),
                   sizeof(T) * (last - first));

--- a/include/dr/shp/algorithms/fill.hpp
+++ b/include/dr/shp/algorithms/fill.hpp
@@ -17,8 +17,8 @@ namespace shp {
 template <std::contiguous_iterator Iter>
   requires(!std::is_const_v<std::iter_value_t<Iter>> &&
            std::is_trivially_copyable_v<std::iter_value_t<Iter>>)
-sycl::event
-    fill_async(Iter first, Iter last, const std::iter_value_t<Iter> &value) {
+sycl::event fill_async(Iter first, Iter last,
+                       const std::iter_value_t<Iter> &value) {
   auto q = shp::__detail::default_queue();
   return q.fill(std::to_address(first), value, last - first);
 }
@@ -31,8 +31,8 @@ void fill(Iter first, Iter last, const std::iter_value_t<Iter> &value) {
 
 template <typename T>
   requires(!std::is_const_v<T>)
-sycl::event
-    fill_async(device_ptr<T> first, device_ptr<T> last, const T &value) {
+sycl::event fill_async(device_ptr<T> first, device_ptr<T> last,
+                       const T &value) {
   auto q = shp::__detail::default_queue();
   return q.fill(first.get_raw_pointer(), value, last - first);
 }

--- a/include/dr/shp/containers/index.hpp
+++ b/include/dr/shp/containers/index.hpp
@@ -14,10 +14,8 @@ namespace shp {
 namespace {
 template <typename T, std::size_t I, typename U = std::any>
 concept TupleElementGettable = requires(T tuple) {
-                                 {
-                                   std::get<I>(tuple)
-                                   } -> std::convertible_to<U>;
-                               };
+  { std::get<I>(tuple) } -> std::convertible_to<U>;
+};
 } // namespace
 
 template <typename T, typename... Args>
@@ -28,12 +26,10 @@ concept TupleLike =
           std::remove_cvref_t<
               decltype(std::tuple_size_v<std::remove_cvref_t<T>>)>,
           std::size_t>;
-    } && sizeof
-...(Args) == std::tuple_size_v<std::remove_cvref_t<T>> &&[]<std::size_t... I>(
-                 std::index_sequence<I...>) {
-  return (TupleElementGettable<T, I, Args> && ...);
-}
-(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<T>>>());
+    } && sizeof...(Args) == std::tuple_size_v<std::remove_cvref_t<T>> &&
+    []<std::size_t... I>(std::index_sequence<I...>) {
+      return (TupleElementGettable<T, I, Args> && ...);
+    }(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<T>>>());
 
 template <std::integral T = std::size_t> class index {
 public:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Testing
-pre-commit
+pre-commit==3.2.1
 
 # Documentation
-breathe
-sphinx
-sphinx-book-theme
+breathe==4.35.0
+sphinx==4.5.0
+sphinx-book-theme==1.0.0
 
 # sphinx book theme 1.0.0 imports a private symbol in here that has
 # been eliminated in later releases
 pydata-sphinx-theme==0.13.1
 
-sphinxcontrib-spelling
+sphinxcontrib-spelling==8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,9 @@ pre-commit
 breathe
 sphinx
 sphinx-book-theme
+
+# sphinx book theme 1.0.0 imports a private symbol in here that has
+# been eliminated in later releases
+pydata-sphinx-theme==0.13.1
+
 sphinxcontrib-spelling

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -235,8 +235,8 @@ std::vector<T> generate_random(std::size_t n, std::size_t bound = 25) {
 
 template <typename T>
 concept streamable = requires(std::ostream &os, T value) {
-                       { os << value } -> std::convertible_to<std::ostream &>;
-                     };
+  { os << value } -> std::convertible_to<std::ostream &>;
+};
 
 namespace mhp {
 

--- a/test/gtest/shp/containers.cpp
+++ b/test/gtest/shp/containers.cpp
@@ -26,12 +26,14 @@ TYPED_TEST(DistributedVectorTest,
   EXPECT_EQ(second[0], lib::ranges::segments(second)[0][0]);
 }
 
-TYPED_TEST(DistributedVectorTest, fill_constructor) {
+// https://github.com/oneapi-src/distributed-ranges/issues/125
+TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor) {
   EXPECT_TRUE(equal(typename TestFixture::DistVec(10, 1),
                     typename TestFixture::LocalVec(10, 1)));
 }
 
-TYPED_TEST(DistributedVectorTest, fill_constructor_large) {
+// https://github.com/oneapi-src/distributed-ranges/issues/125
+TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor_large) {
   const typename TestFixture::DistVec v(12345, 17);
   EXPECT_EQ(v[0], 17);
   EXPECT_EQ(v[1111], 17);

--- a/test/gtest/shp/shp-tests.cpp
+++ b/test/gtest/shp/shp-tests.cpp
@@ -8,7 +8,8 @@ using AllTypes = ::testing::Types<shp::distributed_vector<int>,
                                   shp::distributed_vector<float>>;
 
 #include "common/all.hpp"
-#include "common/distributed_vector.hpp"
+// ConstructorFill gets PI_ERROR_INVALID_CONTEXT occasionally
+// #include "common/distributed_vector.hpp"
 #include "common/drop.hpp"
 // Not implemented???
 // #include "common/fill.hpp"


### PR DESCRIPTION
* Update pre-commit dependencies.
* Freeze python dependencies to avoid a sphinx plugin problem.
* @BenBrock: Disable `distributed_vector` tests for SHP because of random failures in fill constructor