### PR TITLE
using parallel_for instead of fill because of bug in fill

### DIFF
--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -122,7 +122,8 @@ public:
   auto rank() const { return segment_index_; }
   auto local() const { return dv_->data_ + index_ + dv_->halo_bounds_.prev; }
   auto segments() const {
-    return lib::internal::drop_segments(dv_->segments(), index_);
+    return lib::internal::drop_segments(dv_->segments(), segment_index_,
+                                        index_);
   }
   auto &halo() const { return dv_->halo(); }
 

--- a/include/dr/shp/algorithms/fill.hpp
+++ b/include/dr/shp/algorithms/fill.hpp
@@ -20,7 +20,11 @@ template <std::contiguous_iterator Iter>
 sycl::event fill_async(Iter first, Iter last,
                        const std::iter_value_t<Iter> &value) {
   auto q = shp::__detail::default_queue();
-  return q.fill(std::to_address(first), value, last - first);
+  std::iter_value_t<Iter> *arr = std::to_address(first);
+  return q.parallel_for(sycl::range<>(last - first),
+                        [arr, value](auto idx) { arr[idx] = value; });
+  // not using q.fill because of CMPLRLLVM-46438
+  // return q.fill(std::to_address(first), value, last - first);
 }
 
 template <std::contiguous_iterator Iter>
@@ -34,7 +38,11 @@ template <typename T>
 sycl::event fill_async(device_ptr<T> first, device_ptr<T> last,
                        const T &value) {
   auto q = shp::__detail::default_queue();
-  return q.fill(first.get_raw_pointer(), value, last - first);
+  auto *arr = first.get_raw_pointer();
+  return q.parallel_for(sycl::range<>(last - first),
+                        [arr, value](auto idx) { arr[idx] = value; });
+  // not using q.fill because of CMPLRLLVM-46438
+  // return q.fill(first.get_raw_pointer(), value, last - first);
 }
 
 template <typename T>
@@ -46,8 +54,12 @@ void fill(device_ptr<T> first, device_ptr<T> last, const T &value) {
 template <typename T, lib::remote_contiguous_range R>
 sycl::event fill_async(R &&r, const T &value) {
   sycl::queue q(shp::context(), shp::devices()[lib::ranges::rank(r)]);
-  return q.fill(std::to_address(rng::begin(lib::ranges::local(r))), value,
-                rng::distance(r));
+  auto *arr = std::to_address(rng::begin(lib::ranges::local(r)));
+  return q.parallel_for(sycl::range<>(rng::distance(r)),
+                        [arr, value](auto idx) { arr[idx] = value; });
+  // not using q.fill because of CMPLRLLVM-46438
+  // return q.fill(std::to_address(rng::begin(lib::ranges::local(r))), value,
+  //               rng::distance(r));
 }
 
 template <typename T, lib::remote_contiguous_range R>
@@ -72,6 +84,12 @@ template <typename T, lib::distributed_contiguous_range R>
 auto fill(R &&r, const T &value) {
   fill_async(r, value).wait();
   return rng::end(r);
+}
+
+template <typename T, lib::distributed_iterator Iter>
+auto fill(Iter first, Iter last, const T &value) {
+  fill_async(rng::subrange(first, last), value).wait();
+  return last;
 }
 
 } // namespace shp

--- a/test/gtest/include/common/fill.hpp
+++ b/test/gtest/include/common/fill.hpp
@@ -28,3 +28,17 @@ TYPED_TEST(Fill, Iterators) {
   rng::fill(ops.vec.begin() + 1, ops.vec.end() - 1, 33);
   EXPECT_TRUE(check_unary_op(input, ops.vec, ops.dist_vec));
 }
+
+TYPED_TEST(Fill, Iterators_large) {
+  TypeParam large_dist_vec(80000);
+  xhp::fill(large_dist_vec.begin() + 71000, large_dist_vec.end(), 33);
+  EXPECT_EQ(large_dist_vec[77777], 33);
+}
+
+TYPED_TEST(Fill, Iterators_large_segment) {
+  TypeParam large_dist_vec(80000);
+  auto last_segment = large_dist_vec.segments().back();
+  xhp::fill(last_segment.begin(), last_segment.end(),
+            static_cast<typename TypeParam::value_type>(33));
+  EXPECT_EQ(large_dist_vec[79999], 33);
+}

--- a/test/gtest/shp/containers.cpp
+++ b/test/gtest/shp/containers.cpp
@@ -26,14 +26,12 @@ TYPED_TEST(DistributedVectorTest,
   EXPECT_EQ(second[0], lib::ranges::segments(second)[0][0]);
 }
 
-// https://github.com/oneapi-src/distributed-ranges/issues/125
-TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor) {
+TYPED_TEST(DistributedVectorTest, fill_constructor) {
   EXPECT_TRUE(equal(typename TestFixture::DistVec(10, 1),
                     typename TestFixture::LocalVec(10, 1)));
 }
 
-// https://github.com/oneapi-src/distributed-ranges/issues/125
-TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor_large) {
+TYPED_TEST(DistributedVectorTest, fill_constructor_large) {
   const typename TestFixture::DistVec v(12345, 17);
   EXPECT_EQ(v[0], 17);
   EXPECT_EQ(v[1111], 17);
@@ -50,7 +48,7 @@ TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor_large) {
   EXPECT_EQ(v[12344], 17);
 }
 
-TYPED_TEST(DistributedVectorTest, DISABLED_fill_constructor_one_item) {
+TYPED_TEST(DistributedVectorTest, fill_constructor_one_item) {
   EXPECT_TRUE(equal(typename TestFixture::DistVec(1, 77),
                     typename TestFixture::LocalVec(1, 77)));
 }

--- a/test/gtest/shp/shp-tests.cpp
+++ b/test/gtest/shp/shp-tests.cpp
@@ -13,8 +13,7 @@ using AllTypes = ::testing::Types<shp::distributed_vector<int>,
 // need to implement same API as MHP
 // #include "common/copy.hpp"
 #include "common/drop.hpp"
-// Not implemented???
-// #include "common/fill.hpp"
+#include "common/fill.hpp"
 #include "common/for_each.hpp"
 #include "common/reduce.hpp"
 #include "common/subrange.hpp"


### PR DESCRIPTION
workaround fill by not using queue fill, but parallel_for without kernel name
as described in CMPLRLLVM-46438
added unittests failing before and passing after the change