### PR TITLE
iterators use <=>,==

### DIFF
--- a/include/dr/details/iterator_adaptor.hpp
+++ b/include/dr/details/iterator_adaptor.hpp
@@ -63,30 +63,10 @@ public:
     return accessor_ == other.accessor_;
   }
 
-  bool operator!=(const_iterator other) const { return !(*this == other); }
-
-  bool operator<(const_iterator other) const
+  auto operator<=>(const iterator &other) const
     requires(std::is_same_v<iterator_category, std::random_access_iterator_tag>)
   {
-    return accessor_ < other.accessor_;
-  }
-
-  bool operator<=(const_iterator other) const
-    requires(std::is_same_v<iterator_category, std::random_access_iterator_tag>)
-  {
-    return *this < other || *this == other;
-  }
-
-  bool operator>(const_iterator other) const
-    requires(std::is_same_v<iterator_category, std::random_access_iterator_tag>)
-  {
-    return !(*this <= other);
-  }
-
-  bool operator>=(const_iterator other) const
-    requires(std::is_same_v<iterator_category, std::random_access_iterator_tag>)
-  {
-    return !(*this < other);
+    return accessor_ <=> other.accessor_;
   }
 
   reference operator*() const { return *accessor_; }

--- a/include/dr/details/normal_distributed_iterator.hpp
+++ b/include/dr/details/normal_distributed_iterator.hpp
@@ -82,13 +82,11 @@ public:
     return difference_type(get_global_idx()) - other.get_global_idx();
   }
 
-  constexpr bool operator<(const iterator_accessor &other) const noexcept {
-    if (segment_id_ < other.segment_id_) {
-      return true;
-    } else if (segment_id_ == other.segment_id_) {
-      return idx_ < other.idx_;
+  constexpr auto operator<=>(const iterator_accessor &other) const noexcept {
+    if (segment_id_ == other.segment_id_) {
+      return idx_ <=> other.idx_;
     } else {
-      return false;
+      return segment_id_ <=> other.segment_id_;
     }
   }
 

--- a/include/dr/views/transform.hpp
+++ b/include/dr/views/transform.hpp
@@ -53,16 +53,8 @@ public:
     return iter_ - other.iter_;
   }
 
-  bool operator<(iterator other) const noexcept { return iter_ < other.iter_; }
-
-  bool operator>(iterator other) const noexcept { return iter_ > iter_; }
-
-  bool operator<=(iterator other) const noexcept {
-    return iter_ <= other.iter_;
-  }
-
-  bool operator>=(iterator other) const noexcept {
-    return iter_ >= other.iter_;
+  auto operator<=>(const iterator &other) const noexcept {
+    return iter_ <=> other.iter_;
   }
 
   iterator &operator++() noexcept {

--- a/test/gtest/include/common/transform_view.hpp
+++ b/test/gtest/include/common/transform_view.hpp
@@ -71,3 +71,30 @@ TYPED_TEST(TransformView, Reduce) {
   EXPECT_EQ(std::reduce(local.begin(), local.end(), 3, std::plus{}),
             xhp::reduce(default_policy(ops.dist_vec), dist, 3, std::plus{}));
 }
+
+TYPED_TEST(TransformView, IteratorRelational) {
+  Ops1<TypeParam> ops(10);
+
+  auto negate = [](auto &&v) { return -v; };
+  auto it = lib::views::transform(ops.dist_vec, negate).begin();
+
+  EXPECT_TRUE(it == it);
+  EXPECT_FALSE(it == it + 1);
+
+  EXPECT_TRUE(it != it + 1);
+  EXPECT_FALSE(it != it);
+
+  EXPECT_TRUE(it < it + 1);
+  EXPECT_FALSE(it < it);
+
+  EXPECT_TRUE(it <= it + 1);
+  EXPECT_TRUE(it <= it);
+  EXPECT_FALSE(it + 1 <= it);
+
+  EXPECT_TRUE(it + 1 > it);
+  EXPECT_FALSE(it > it);
+
+  EXPECT_TRUE(it + 1 >= it);
+  EXPECT_TRUE(it >= it);
+  EXPECT_FALSE(it >= it + 1);
+}


### PR DESCRIPTION
Convert some iterators to use <=>, == to define all relational operations