### PR TITLE
Allow calling algorithms without execution policy

### DIFF
--- a/include/dr/shp/algorithms/for_each.hpp
+++ b/include/dr/shp/algorithms/for_each.hpp
@@ -42,4 +42,13 @@ void for_each(ExecutionPolicy &&policy, Iter begin, Iter end, Fn &&fn) {
            std::forward<Fn>(fn));
 }
 
+template <lib::distributed_range R, typename Fn> void for_each(R &&r, Fn &&fn) {
+  for_each(shp::par_unseq, std::forward<R>(r), std::forward<Fn>(fn));
+}
+
+template <lib::distributed_iterator Iter, typename Fn>
+void for_each(Iter begin, Iter end, Fn &&fn) {
+  for_each(shp::par_unseq, begin, end, std::forward<Fn>(fn));
+}
+
 } // namespace shp

--- a/include/dr/shp/algorithms/inclusive_scan.hpp
+++ b/include/dr/shp/algorithms/inclusive_scan.hpp
@@ -204,4 +204,49 @@ OutputIter inclusive_scan(ExecutionPolicy &&policy, Iter first, Iter last,
   return d_last;
 }
 
+// Execution policy-less versions
+
+template <lib::distributed_contiguous_range R,
+          lib::distributed_contiguous_range O>
+void inclusive_scan(R &&r, O &&o) {
+  inclusive_scan(shp::par_unseq, std::forward<R>(r), std::forward<O>(o));
+}
+
+template <lib::distributed_contiguous_range R,
+          lib::distributed_contiguous_range O, typename BinaryOp>
+void inclusive_scan(R &&r, O &&o, BinaryOp &&binary_op) {
+  inclusive_scan(shp::par_unseq, std::forward<R>(r), std::forward<O>(o),
+                 std::forward<BinaryOp>(binary_op));
+}
+
+template <lib::distributed_contiguous_range R,
+          lib::distributed_contiguous_range O, typename BinaryOp, typename T>
+void inclusive_scan(R &&r, O &&o, BinaryOp &&binary_op, T init) {
+  inclusive_scan(shp::par_unseq, std::forward<R>(r), std::forward<O>(o),
+                 std::forward<BinaryOp>(binary_op), init);
+}
+
+// Distributed iterator versions
+
+template <lib::distributed_iterator Iter, lib::distributed_iterator OutputIter>
+OutputIter inclusive_scan(Iter first, Iter last, OutputIter d_first) {
+  return inclusive_scan(shp::par_unseq, first, last, d_first);
+}
+
+template <lib::distributed_iterator Iter, lib::distributed_iterator OutputIter,
+          typename BinaryOp>
+OutputIter inclusive_scan(Iter first, Iter last, OutputIter d_first,
+                          BinaryOp &&binary_op) {
+  return inclusive_scan(shp::par_unseq, first, last, d_first,
+                        std::forward<BinaryOp>(binary_op));
+}
+
+template <lib::distributed_iterator Iter, lib::distributed_iterator OutputIter,
+          typename BinaryOp, typename T>
+OutputIter inclusive_scan(Iter first, Iter last, OutputIter d_first,
+                          BinaryOp &&binary_op, T init) {
+  return inclusive_scan(shp::par_unseq, first, last, d_first,
+                        std::forward<BinaryOp>(binary_op), init);
+}
+
 } // namespace shp

--- a/include/dr/shp/algorithms/reduce.hpp
+++ b/include/dr/shp/algorithms/reduce.hpp
@@ -135,4 +135,36 @@ T reduce(ExecutionPolicy &&policy, Iter first, Iter last, T init,
                 std::forward<BinaryOp>(binary_op));
 }
 
+// Execution policy-less algorithms
+
+template <lib::distributed_range R> rng::range_value_t<R> reduce(R &&r) {
+  return reduce(shp::par_unseq, std::forward<R>(r));
+}
+
+template <lib::distributed_range R, typename T> T reduce(R &&r, T init) {
+  return reduce(shp::par_unseq, std::forward<R>(r), init);
+}
+
+template <lib::distributed_range R, typename T, typename BinaryOp>
+T reduce(R &&r, T init, BinaryOp &&binary_op) {
+  return reduce(shp::par_unseq, std::forward<R>(r), init,
+                std::forward<BinaryOp>(binary_op));
+}
+
+template <lib::distributed_iterator Iter>
+std::iter_value_t<Iter> reduce(Iter first, Iter last) {
+  return reduce(shp::par_unseq, first, last);
+}
+
+template <lib::distributed_iterator Iter, typename T>
+T reduce(Iter first, Iter last, T init) {
+  return reduce(shp::par_unseq, first, last, init);
+}
+
+template <lib::distributed_iterator Iter, typename T, typename BinaryOp>
+T reduce(Iter first, Iter last, T init, BinaryOp &&binary_op) {
+  return reduce(shp::par_unseq, first, last, init,
+                std::forward<BinaryOp>(binary_op));
+}
+
 } // namespace shp

--- a/test/gtest/shp/algorithms.cpp
+++ b/test/gtest/shp/algorithms.cpp
@@ -12,96 +12,195 @@ using V = std::vector<T>;
 TEST(ShpTests, InclusiveScan_aligned) {
   std::size_t n = 100;
 
-  shp::distributed_vector<int, shp::device_allocator<int>> v(n);
-  std::vector<int> lv(n);
+  // With execution Policy
+  {
+    shp::distributed_vector<int, shp::device_allocator<int>> v(n);
+    std::vector<int> lv(n);
 
-  // Range case, no binary op or init, perfectly aligned
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
+    // Range case, no binary op or init, perfectly aligned
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(shp::par_unseq, v, v);
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], v[i]);
+    }
+
+    // Iterator case, no binary op or init, perfectly aligned
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), v.begin());
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], v[i]);
+    }
   }
-  shp::copy(lv.begin(), lv.end(), v.begin());
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
-  shp::inclusive_scan(shp::par_unseq, v, v);
+  // Without execution policies
+  {
+    shp::distributed_vector<int, shp::device_allocator<int>> v(n);
+    std::vector<int> lv(n);
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], v[i]);
-  }
+    // Range case, no binary op or init, perfectly aligned
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
 
-  // Iterator case, no binary op or init, perfectly aligned
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
-  }
-  shp::copy(lv.begin(), lv.end(), v.begin());
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(v, v);
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
-  shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), v.begin());
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], v[i]);
+    }
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], v[i]);
+    // Iterator case, no binary op or init, perfectly aligned
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(v.begin(), v.end(), v.begin());
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], v[i]);
+    }
   }
 }
 
 TEST(ShpTests, DISABLED_InclusiveScan_nonaligned) {
   std::size_t n = 100;
 
-  shp::distributed_vector<int, shp::device_allocator<int>> v(n);
-  shp::distributed_vector<int, shp::device_allocator<int>> o(v.size() * 2);
-  std::vector<int> lv(n);
+  // With execution policies
+  {
+    shp::distributed_vector<int, shp::device_allocator<int>> v(n);
+    shp::distributed_vector<int, shp::device_allocator<int>> o(v.size() * 2);
+    std::vector<int> lv(n);
 
-  // Range case, binary op no init, non-aligned ranges
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
+    // Range case, binary op no init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(shp::par_unseq, v, o, std::plus<>());
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
+
+    // Range case, binary op, init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
+                        12);
+    shp::inclusive_scan(shp::par_unseq, v, o, std::multiplies<>(), 12);
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
+
+    // Iterator case, binary op no init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), o.begin(),
+                        std::plus<>());
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
+
+    // Range case, binary op, init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
+                        12);
+    shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), o.begin(),
+                        std::multiplies<>(), 12);
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
   }
-  shp::copy(lv.begin(), lv.end(), v.begin());
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
-  shp::inclusive_scan(shp::par_unseq, v, o, std::plus<>());
+  // Without execution policies
+  {
+    shp::distributed_vector<int, shp::device_allocator<int>> v(n);
+    shp::distributed_vector<int, shp::device_allocator<int>> o(v.size() * 2);
+    std::vector<int> lv(n);
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], o[i]);
-  }
+    // Range case, binary op no init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
 
-  // Range case, binary op, init, non-aligned ranges
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
-  }
-  shp::copy(lv.begin(), lv.end(), v.begin());
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(v, o, std::plus<>());
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
-                      12);
-  shp::inclusive_scan(shp::par_unseq, v, o, std::multiplies<>(), 12);
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], o[i]);
-  }
+    // Range case, binary op, init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
 
-  // Iterator case, binary op no init, non-aligned ranges
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
-  }
-  shp::copy(lv.begin(), lv.end(), v.begin());
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
+                        12);
+    shp::inclusive_scan(v, o, std::multiplies<>(), 12);
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
-  shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), o.begin(),
-                      std::plus<>());
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], o[i]);
-  }
+    // Iterator case, binary op no init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
 
-  // Range case, binary op, init, non-aligned ranges
-  for (auto &&x : lv) {
-    x = lrand48() % 100;
-  }
-  shp::copy(lv.begin(), lv.end(), v.begin());
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin());
+    shp::inclusive_scan(v.begin(), v.end(), o.begin(), std::plus<>());
 
-  std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
-                      12);
-  shp::inclusive_scan(shp::par_unseq, v.begin(), v.end(), o.begin(),
-                      std::multiplies<>(), 12);
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
 
-  for (std::size_t i = 0; i < lv.size(); i++) {
-    EXPECT_EQ(lv[i], o[i]);
+    // Range case, binary op, init, non-aligned ranges
+    for (auto &&x : lv) {
+      x = lrand48() % 100;
+    }
+    shp::copy(lv.begin(), lv.end(), v.begin());
+
+    std::inclusive_scan(lv.begin(), lv.end(), lv.begin(), std::multiplies<>(),
+                        12);
+    shp::inclusive_scan(v.begin(), v.end(), o.begin(), std::multiplies<>(), 12);
+
+    for (std::size_t i = 0; i < lv.size(); i++) {
+      EXPECT_EQ(lv[i], o[i]);
+    }
   }
 }


### PR DESCRIPTION
Allow calling algorithms without execution policy in `shp`.

Calling an algorithm without an execution policy is equivalent to calling it with `shp::par_unseq`.