### PR TITLE
fixed dv_segments and enabled mhp::take tests

### DIFF
--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -159,7 +159,8 @@ private:
   std::size_t size_;
 }; // dv_segment
 
-template <typename DV> class dv_segments : public std::span<dv_segment<DV>> {
+template <typename DV>
+class dv_segments : public std::span<dv_segment<DV>>, rng::view_base {
 public:
   dv_segments() {}
   dv_segments(DV *dv) : std::span<dv_segment<DV>>(dv->segments_) { dv_ = dv; }

--- a/test/gtest/mhp/mhp-tests.cpp
+++ b/test/gtest/mhp/mhp-tests.cpp
@@ -32,8 +32,7 @@ using CPUTypes = ::testing::Types<mhp::distributed_vector<int>,
 #include "common/iota.hpp"
 #include "common/reduce.hpp"
 #include "common/subrange.hpp"
-// Fails with everyting but g++12
-// #include "common/take.hpp"
+#include "common/take.hpp"
 #include "common/transform_view.hpp"
 #include "common/zip.hpp"
 


### PR DESCRIPTION
code was failing because dv_segments was treated by ranges library as a container and was wrapped by ref_view. ref_view takes address by object it references. But dv_segments happens to be a temporary object, so its address was becoming invalid. be deriving from view_base we instruct ranges library to treat dv_segments a view, not warp it by ref_view, but simply copy