### PR TITLE
cmake example and remove dependence on format

### DIFF
--- a/include/dr/detail/halo.hpp
+++ b/include/dr/detail/halo.hpp
@@ -388,9 +388,13 @@ private:
 
 } // namespace dr
 
+#ifdef DR_FORMAT
+
 template <> struct fmt::formatter<dr::halo_bounds> : formatter<string_view> {
   template <typename FmtContext>
   auto format(dr::halo_bounds hb, FmtContext &ctx) {
     return format_to(ctx.out(), "prev: {} next: {}", hb.prev, hb.next);
   }
 };
+
+#endif

--- a/include/dr/mhp.hpp
+++ b/include/dr/mhp.hpp
@@ -24,8 +24,11 @@
 #include <utility>
 #include <vector>
 
+#ifdef DR_FORMAT
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#endif
+
 // Workaround for doxygen warning about internal inconsistency
 namespace fmt {}
 

--- a/test/cmake-application/CMakeLists.txt
+++ b/test/cmake-application/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.20)
+project(cmake-applications)
+
+find_package(MPI REQUIRED)
+include(FetchContent)
+FetchContent_Declare(
+  dr
+  GIT_REPOSITORY https://github.com/oneapi-src/distributed-ranges.git
+  GIT_TAG main
+  )
+FetchContent_MakeAvailable(dr)
+
+set(CMAKE_CXX_STANDARD 20)
+add_executable(mhp-app mhp-app.cpp)
+target_link_libraries(mhp-app MPI::MPI_CXX DR::mpi)

--- a/test/cmake-application/mhp-app.cpp
+++ b/test/cmake-application/mhp-app.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "mpi.h"
+
+#include "dr/mhp.hpp"
+
+using T = int;
+
+MPI_Comm comm;
+int comm_rank;
+
+const std::size_t n = 10;
+
+void vector_add() {
+  dr::mhp::distributed_vector<T> a(n), b(n), c(n);
+
+  // Initialize
+  dr::mhp::iota(a, 10);
+  dr::mhp::iota(b, 100);
+
+  auto add = [](auto ops) { return ops.first + ops.second; };
+
+  dr::mhp::transform(dr::mhp::views::zip(a, b), c.begin(), add);
+}
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  comm = MPI_COMM_WORLD;
+  MPI_Comm_rank(comm, &comm_rank);
+  dr::mhp::init();
+
+  vector_add();
+
+  MPI_Finalize();
+  return 0;
+}


### PR DESCRIPTION
@tkarna: This should remove the dependence on format library.

I made an example, but not sure how to test in ci. This will download default branch from git. You can use the `URL` instead of `GIT_REPOSITORY` with `fetchcontent`, but you have to restructure the directory so the build directory is not in the tree.