### PR TITLE
serial slide stencil

### DIFF
--- a/examples/mhp/CMakeLists.txt
+++ b/examples/mhp/CMakeLists.txt
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+add_executable(stencil-slide stencil-slide.cpp)
+target_link_libraries(stencil-slide cxxopts DR::mpi)
+
 add_executable(vector-add vector-add.cpp)
 target_link_libraries(vector-add DR::mpi)
 add_mpi_test(vector-add vector-add 2)

--- a/examples/mhp/stencil-slide.cpp
+++ b/examples/mhp/stencil-slide.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "dr/mhp.hpp"
+
+#include "cxxopts.hpp"
+
+cxxopts::ParseResult options;
+
+auto stencil_op = [](auto &&r) { return r[0] + r[1] + r[2]; };
+
+int stencil(auto n, auto steps) {
+  std::vector<int> a(n), b(n);
+  rng::fill(a, 0);
+  rng::fill(b, 0);
+
+  // Input is a window
+  auto in_curr = rng::views::sliding(a, 3);
+  auto in_prev = rng::views::sliding(b, 3);
+
+  // Output is an element
+  auto out_curr = rng::subrange(b.begin() + 1, b.end() - 1);
+  auto out_prev = rng::subrange(a.begin() + 1, a.end() - 1);
+
+  // Initialize the input
+  rng::iota(out_prev, 100);
+  fmt::print("{}\n\n", a);
+
+  for (std::size_t s = 0; s < steps; s++) {
+    rng::transform(in_curr, out_curr.begin(), stencil_op);
+    std::swap(in_curr, in_prev);
+    std::swap(out_curr, out_prev);
+    fmt::print("{}\n", s % 2 ? a : b);
+  }
+
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  cxxopts::Options options_spec(argv[0], "stencil 1d");
+  // clang-format off
+  options_spec.add_options()
+    ("n", "Size of array", cxxopts::value<std::size_t>()->default_value("10"))
+    ("s", "Number of time steps", cxxopts::value<std::size_t>()->default_value("5"))
+    ("help", "Print help");
+  // clang-format on
+
+  try {
+    options = options_spec.parse(argc, argv);
+  } catch (const cxxopts::OptionParseException &e) {
+    std::cout << options_spec.help() << "\n";
+    exit(1);
+  }
+
+  auto error =
+      stencil(options["n"].as<std::size_t>(), options["s"].as<std::size_t>());
+
+  return error;
+}


### PR DESCRIPTION
@BenBrock @mateuszpn 

This is the serial stencil using `rng::views::sliding`

Output:
```
[0, 100, 101, 102, 103, 104, 105, 106, 107, 0]

[0, 201, 303, 306, 309, 312, 315, 318, 213, 0]
[0, 504, 810, 918, 927, 936, 945, 846, 531, 0]
[0, 1314, 2232, 2655, 2781, 2808, 2727, 2322, 1377, 0]
[0, 3546, 6201, 7668, 8244, 8316, 7857, 6426, 3699, 0]
[0, 9747, 17415, 22113, 24228, 24417, 22599, 17982, 10125, 0]
```