### PR TITLE
mhp switch local to use segment, not iterator

### DIFF
--- a/include/dr/detail/ranges.hpp
+++ b/include/dr/detail/ranges.hpp
@@ -152,8 +152,10 @@ struct local_fn_ {
              std::contiguous_iterator<rng::iterator_t<R>> ||
              rng::contiguous_range<R>)
   auto operator()(R &&r) const {
-    if constexpr (has_local_method<rng::iterator_t<R>>) {
-      return std::span(rng::begin(r).local(), rng::size(r));
+    if constexpr (has_local_method<R>) {
+      return r.local();
+    } else if constexpr (has_local_method<rng::iterator_t<R>>) {
+      return rng::views::counted(rng::begin(r).local(), rng::size(r));
     } else if constexpr (has_local_adl<R>) {
       return local_(std::forward<R>(r));
     } else if constexpr (std::contiguous_iterator<rng::iterator_t<R>>) {

--- a/include/dr/mhp/views/views.hpp
+++ b/include/dr/mhp/views/views.hpp
@@ -16,8 +16,7 @@ template <typename R> auto local_segments(R &&dr) {
   };
   // Convert from remote iter to local iter
   auto local_iter = [](const auto &segment) {
-    auto b = dr::ranges::local(rng::begin(segment));
-    return rng::subrange(b, b + rng::distance(segment));
+    return dr::ranges::local(segment);
   };
   return dr::ranges::segments(std::forward<R>(dr)) |
          rng::views::filter(is_local) | rng::views::transform(local_iter);


### PR DESCRIPTION
MHP constructed a local range from local iterators. Switch to requesting a local range from the segment. MHP always has a segment when it needs local iterators and this will simplify some views. The CPO for getting the local range will construct it when only the iterators implement local.

The CPO used `std::span` to construct the local range, but the constructor it used only works for contiguous range and some views were not providing that. Switch to `ranges::views::counted``.


