### PR TITLE
use slice instead of remote_subrange

### DIFF
--- a/include/dr/detail/segments_tools.hpp
+++ b/include/dr/detail/segments_tools.hpp
@@ -41,14 +41,8 @@ auto take_segments(R &&segments, std::size_t segment_id, std::size_t local_id) {
 
   auto take_partial = [=](auto &&v) {
     auto &&[i, segment] = v;
-    if (i == last_seg) {
-      auto first = rng::begin(segment);
-      auto last = rng::begin(segment);
-      rng::advance(last, remainder);
-      return dr::remote_subrange(first, last, dr::ranges::rank(segment));
-    } else {
-      return dr::remote_subrange(segment);
-    }
+    return rng::views::slice(segment, 0,
+                             i == last_seg ? remainder : rng::size(segment));
   };
 
   return enumerate(segments) | rng::views::take(last_seg + 1) |
@@ -71,14 +65,8 @@ auto drop_segments(R &&segments, std::size_t segment_id, std::size_t local_id) {
 
   auto drop_partial = [=](auto &&v) {
     auto &&[i, segment] = v;
-    if (i == last_seg) {
-      auto first = rng::begin(segment);
-      rng::advance(first, remainder);
-      auto last = rng::end(segment);
-      return dr::remote_subrange(first, last, dr::ranges::rank(segment));
-    } else {
-      return dr::remote_subrange(segment);
-    }
+    return rng::views::slice(segment, i == last_seg ? remainder : 0,
+                             rng::size(segment));
   };
 
   return enumerate(segments) | rng::views::drop(last_seg) |

--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -36,7 +36,13 @@ add_executable(
   copy-3.cpp
 )
 
-foreach(test-exec IN ITEMS shp-tests shp-tests-3)
+add_executable(
+  my-tests
+  shp-tests.cpp
+  take.cpp
+)
+
+foreach(test-exec IN ITEMS shp-tests shp-tests-3 my-tests)
   target_link_libraries(
     ${test-exec}
     GTest::gtest_main

--- a/test/gtest/shp/take.cpp
+++ b/test/gtest/shp/take.cpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+#include "xhp-tests.hpp"
+
+TEST(Take, Basic) {
+  dr::shp::distributed_vector<int> x(10);
+  x.segments();
+  // rng::iota(x, 100);
+  fmt::print("x: {}\n", x);
+  fmt::print("segments: {}\n", dr::ranges::segments(x));
+}


### PR DESCRIPTION
Use rng::slice_view instead of remote_range. It works for mhp, but does not compile with shp. I think the problem is that segment_tools uses rng::zip_view and it does not propagate a rank.

Setting this aside.