### PR TITLE
Implement `shp::sort`

### DIFF
--- a/examples/shp/CMakeLists.txt
+++ b/examples/shp/CMakeLists.txt
@@ -21,6 +21,7 @@ endfunction()
 add_shp_example(vector_example)
 add_shp_example(test_range)
 add_shp_example(dot_product)
+add_shp_example(sort)
 add_shp_example(dot_product_benchmark)
 add_shp_example(inclusive_scan_example)
 # unsatisfied dependency of grb/grb.hpp

--- a/examples/shp/CMakeLists.txt
+++ b/examples/shp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_shp_example(test_range)
 add_shp_example(dot_product)
 add_shp_example(sort)
 add_shp_example(dot_product_benchmark)
+add_shp_example(sort_benchmark)
 add_shp_example(inclusive_scan_example)
 # unsatisfied dependency of grb/grb.hpp
 # add_shp_example(gemv_benchmark)

--- a/examples/shp/sort.cpp
+++ b/examples/shp/sort.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <dr/shp.hpp>
 
 #include <oneapi/dpl/algorithm>
@@ -7,168 +11,23 @@
 
 namespace shp = dr::shp;
 
-template <rng::forward_range T>
-void range(T&&) {}
-
-template <typename T, typename Allocator = dr::shp::device_allocator<T>>
-class fast_queue {
-public:
-
-  using index_type = std::size_t;
-
-  using allocator_type = Allocator;
-
-  fast_queue(std::size_t capacity, std::size_t rank)
-    : rank_(rank), data_(capacity, Allocator(shp::context(), shp::devices()[rank])) {
-
-    auto&& alloc = data_.get_allocator();
-
-    begin_ = 0;
-    end_ = 0;
-  }
-
-  template <rng::random_access_range R>
-  std::pair<sycl::event, bool> push(R&& r) {
-    std::size_t s = rng::size(r);
-
-    // Reserve a spot in the queue
-    std::size_t spot = end_handle_().fetch_add(s, std::memory_order_relaxed);
-
-    std::size_t begin_c = begin_handle_();
-
-    if (spot - begin_c > data_.size()) {
-      end_handle_() -= s;
-      return {sycl::event{}, false};
-    } else {
-      return {shp::copy_async(r.begin(), r.end(), data_.begin() + spot), true};
-    }
-  }
-
-  auto begin() {
-    std::size_t begin_c = begin_handle_();
-    return data_.begin() + (begin_c % data_.size());
-  }
-
-  auto end() {
-    std::size_t end_c = end_handle_();
-    return data_.begin() + (end_c & data_.size());
-  }
-
-  std::size_t capacity() const {
-    return data_.size();
-  }
-
-  std::size_t size() const {
-
-  }
-
-private:
-  auto begin_handle_() { return std::atomic_ref(begin_); }
-  auto begin_handle_() const { return std::atomic_ref(begin_); }
-
-  auto end_handle_() { return std::atomic_ref(end_); }
-  auto end_handle_() const { return std::atomic_ref(end_); }
-
-private:
-  std::size_t rank_;
-  dr::shp::device_vector<T, Allocator> data_;
-  index_type begin_ = 0;
-  index_type end_ = 0;
-};
-
-template <dr::distributed_range R, typename Compare = std::less<>>
-void sort(R&& r, Compare comp = Compare()) {
-  using T = rng::range_value_t<R>;
-  std::vector<sycl::event> events;
-
-  auto&& segments = dr::ranges::segments(r);
-
-  std::size_t n_segments = std::size_t(rng::size(segments));
-  std::size_t n_splitters = n_segments - 1;
-
-  T* medians = sycl::malloc_shared<T>(n_segments * n_splitters, shp::devices()[0], shp::context());
-
-  std::size_t segment_id = 0;
-
-  for (auto&& segment : segments) {
-    auto&& q = dr::shp::__detail::queue(dr::ranges::rank(segment));
-    auto&& local_policy = dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
-
-    auto&& local_segment = dr::shp::__detail::local(segment);
-    dr::__detail::direct_iterator local_begin(rng::begin(local_segment));
-    dr::__detail::direct_iterator local_end(rng::end(local_segment));
-
-    sycl::event s = oneapi::dpl::experimental::sort_async(local_policy, local_begin, local_end);
-
-    double step_size = static_cast<double>(rng::size(segment)) / n_segments;
-
-    auto e = q.submit([&](auto&& h) {
-      h.depends_on(s);
-
-      h.parallel_for(n_splitters,
-                     [=](auto i) {
-                       medians[n_splitters*segment_id + i] = local_begin[step_size * (i+1) + 0.5];
-                     });
-    });
-
-    events.push_back(e);
-    ++segment_id;
-  }
-
-  dr::shp::__detail::wait(events);
-
-  auto&& local_policy = dr::shp::__detail::dpl_policy(0);
-  oneapi::dpl::experimental::sort_async(local_policy, medians, medians + n_segments*n_splitters).wait();
-
-  double step_size = static_cast<double>(n_segments*n_splitters) / n_segments;
-
-  // - Collect median of medians to get final splitters.
-  // - Write splitters to [0, n_splitters) in `medians`
-  for (std::size_t i = 0; i < n_splitters; i++) {
-    medians[i] = medians[std::size_t(step_size * (i+1) + 0.5)];
-  }
-
-  segment_id = 0;
-  for (auto&& segment : segments) {
-    auto&& q = dr::shp::__detail::queue(dr::ranges::rank(segment));
-    auto&& local_policy = dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
-
-    auto&& local_segment = dr::shp::__detail::local(segment);
-    dr::__detail::direct_iterator local_begin(rng::begin(local_segment));
-    dr::__detail::direct_iterator local_end(rng::end(local_segment));
-
-    fmt::print("Segment {}: {}\n", dr::ranges::rank(segment), local_segment);
-
-    for (std::size_t i = 0; i < n_splitters; i++) {
-      auto lower_bound = oneapi::dpl::lower_bound(local_policy, local_begin, local_end, local_begin, local_end, medians[i], comp);
-
-      fmt::print("Sending {} -> {}\n", rng::subrange(local_begin, lower_bound), i);
-      local_begin = lower_bound;
-    }
-
-    ++segment_id;
-  }
-
-  fmt::print("Medians: ");
-  for (std::size_t i = 0; i < n_splitters; i++) {
-    fmt::print("{} ", medians[i]);
-  }
-  fmt::print("\n");
-}
-
-int main(int argc, char** argv) {
-  auto devices = shp::get_numa_devices(sycl::default_selector_v);
+int main(int argc, char **argv) {
+  auto devices = shp::get_duplicated_devices(sycl::default_selector_v, 4);
   shp::init(devices);
 
-  std::size_t n = 1000;
+  std::size_t n = 100;
 
   shp::distributed_vector<int> v(n);
 
+  srand48(time(0));
+
   for (std::size_t i = 0; i < v.size(); i++) {
-    v[i] = lrand48() % 100;
+    v[i] = lrand48() % 1000;
   }
 
   sort(v);
+
+  fmt::print("v: {}\n", v);
 
   return 0;
 }

--- a/examples/shp/sort.cpp
+++ b/examples/shp/sort.cpp
@@ -12,10 +12,10 @@
 namespace shp = dr::shp;
 
 int main(int argc, char **argv) {
-  auto devices = shp::get_duplicated_devices(sycl::default_selector_v, 4);
+  auto devices = shp::get_numa_devices(sycl::default_selector_v);
   shp::init(devices);
 
-  std::size_t n = 100;
+  std::size_t n = 1000;
 
   shp::distributed_vector<int> v(n);
 

--- a/examples/shp/sort.cpp
+++ b/examples/shp/sort.cpp
@@ -1,0 +1,174 @@
+#include <dr/shp.hpp>
+
+#include <oneapi/dpl/algorithm>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+namespace shp = dr::shp;
+
+template <rng::forward_range T>
+void range(T&&) {}
+
+template <typename T, typename Allocator = dr::shp::device_allocator<T>>
+class fast_queue {
+public:
+
+  using index_type = std::size_t;
+
+  using allocator_type = Allocator;
+
+  fast_queue(std::size_t capacity, std::size_t rank)
+    : rank_(rank), data_(capacity, Allocator(shp::context(), shp::devices()[rank])) {
+
+    auto&& alloc = data_.get_allocator();
+
+    begin_ = 0;
+    end_ = 0;
+  }
+
+  template <rng::random_access_range R>
+  std::pair<sycl::event, bool> push(R&& r) {
+    std::size_t s = rng::size(r);
+
+    // Reserve a spot in the queue
+    std::size_t spot = end_handle_().fetch_add(s, std::memory_order_relaxed);
+
+    std::size_t begin_c = begin_handle_();
+
+    if (spot - begin_c > data_.size()) {
+      end_handle_() -= s;
+      return {sycl::event{}, false};
+    } else {
+      return {shp::copy_async(r.begin(), r.end(), data_.begin() + spot), true};
+    }
+  }
+
+  auto begin() {
+    std::size_t begin_c = begin_handle_();
+    return data_.begin() + (begin_c % data_.size());
+  }
+
+  auto end() {
+    std::size_t end_c = end_handle_();
+    return data_.begin() + (end_c & data_.size());
+  }
+
+  std::size_t capacity() const {
+    return data_.size();
+  }
+
+  std::size_t size() const {
+
+  }
+
+private:
+  auto begin_handle_() { return std::atomic_ref(begin_); }
+  auto begin_handle_() const { return std::atomic_ref(begin_); }
+
+  auto end_handle_() { return std::atomic_ref(end_); }
+  auto end_handle_() const { return std::atomic_ref(end_); }
+
+private:
+  std::size_t rank_;
+  dr::shp::device_vector<T, Allocator> data_;
+  index_type begin_ = 0;
+  index_type end_ = 0;
+};
+
+template <dr::distributed_range R, typename Compare = std::less<>>
+void sort(R&& r, Compare comp = Compare()) {
+  using T = rng::range_value_t<R>;
+  std::vector<sycl::event> events;
+
+  auto&& segments = dr::ranges::segments(r);
+
+  std::size_t n_segments = std::size_t(rng::size(segments));
+  std::size_t n_splitters = n_segments - 1;
+
+  T* medians = sycl::malloc_shared<T>(n_segments * n_splitters, shp::devices()[0], shp::context());
+
+  std::size_t segment_id = 0;
+
+  for (auto&& segment : segments) {
+    auto&& q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+    auto&& local_policy = dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+
+    auto&& local_segment = dr::shp::__detail::local(segment);
+    dr::__detail::direct_iterator local_begin(rng::begin(local_segment));
+    dr::__detail::direct_iterator local_end(rng::end(local_segment));
+
+    sycl::event s = oneapi::dpl::experimental::sort_async(local_policy, local_begin, local_end);
+
+    double step_size = static_cast<double>(rng::size(segment)) / n_segments;
+
+    auto e = q.submit([&](auto&& h) {
+      h.depends_on(s);
+
+      h.parallel_for(n_splitters,
+                     [=](auto i) {
+                       medians[n_splitters*segment_id + i] = local_begin[step_size * (i+1) + 0.5];
+                     });
+    });
+
+    events.push_back(e);
+    ++segment_id;
+  }
+
+  dr::shp::__detail::wait(events);
+
+  auto&& local_policy = dr::shp::__detail::dpl_policy(0);
+  oneapi::dpl::experimental::sort_async(local_policy, medians, medians + n_segments*n_splitters).wait();
+
+  double step_size = static_cast<double>(n_segments*n_splitters) / n_segments;
+
+  // - Collect median of medians to get final splitters.
+  // - Write splitters to [0, n_splitters) in `medians`
+  for (std::size_t i = 0; i < n_splitters; i++) {
+    medians[i] = medians[std::size_t(step_size * (i+1) + 0.5)];
+  }
+
+  segment_id = 0;
+  for (auto&& segment : segments) {
+    auto&& q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+    auto&& local_policy = dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+
+    auto&& local_segment = dr::shp::__detail::local(segment);
+    dr::__detail::direct_iterator local_begin(rng::begin(local_segment));
+    dr::__detail::direct_iterator local_end(rng::end(local_segment));
+
+    fmt::print("Segment {}: {}\n", dr::ranges::rank(segment), local_segment);
+
+    for (std::size_t i = 0; i < n_splitters; i++) {
+      auto lower_bound = oneapi::dpl::lower_bound(local_policy, local_begin, local_end, local_begin, local_end, medians[i], comp);
+
+      fmt::print("Sending {} -> {}\n", rng::subrange(local_begin, lower_bound), i);
+      local_begin = lower_bound;
+    }
+
+    ++segment_id;
+  }
+
+  fmt::print("Medians: ");
+  for (std::size_t i = 0; i < n_splitters; i++) {
+    fmt::print("{} ", medians[i]);
+  }
+  fmt::print("\n");
+}
+
+int main(int argc, char** argv) {
+  auto devices = shp::get_numa_devices(sycl::default_selector_v);
+  shp::init(devices);
+
+  std::size_t n = 1000;
+
+  shp::distributed_vector<int> v(n);
+
+  for (std::size_t i = 0; i < v.size(); i++) {
+    v[i] = lrand48() % 100;
+  }
+
+  sort(v);
+
+  return 0;
+}

--- a/examples/shp/sort_benchmark.cpp
+++ b/examples/shp/sort_benchmark.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <dr/shp.hpp>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/async>
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/numeric>
+
+template <dr::distributed_range X, typename Compare = std::less<>>
+auto sort_distributed(X &&x, Compare comp = Compare()) {
+  dr::shp::sort(x.begin(), x.end(), comp);
+}
+
+template <rng::random_access_range X, typename Compare = std::less<>>
+auto sort_onedpl(sycl::queue q, X &&x, Compare comp = Compare()) {
+  oneapi::dpl::execution::device_policy policy(q);
+  dr::__detail::direct_iterator d_first(x.begin());
+  dr::__detail::direct_iterator d_last(x.end());
+  oneapi::dpl::experimental::sort_async(policy, d_first, d_last, comp).wait();
+}
+
+template <rng::forward_range X, typename Compare = std::less<>>
+auto sort_sequential(X &&x, Compare comp = Compare()) {
+  std::sort(x.begin(), x.end(), comp);
+}
+
+template <rng::forward_range X> void fill_random(X &&x) {
+  for (auto &&value : x) {
+    value = drand48() * 100;
+  }
+}
+
+int main(int argc, char **argv) {
+  auto devices_ = dr::shp::get_numa_devices(sycl::default_selector_v);
+  // auto devices = dr::shp::trim_devices(devices_, 8);
+  auto devices = devices_;
+  dr::shp::init(devices);
+
+  // Note that parallel results will not match sequential
+  // results for large sizes due to floating point addition
+  // non-determinism.
+  // This does not indicate the benchmark is failing.
+  std::size_t n = 32ull * 1000 * 1000ull;
+
+  using T = float;
+
+  std::vector<T> x_local(n, 1);
+  fill_random(x_local);
+
+  std::vector<T> v_serial = x_local;
+
+  sort_sequential(v_serial);
+
+  dr::shp::distributed_vector<T> x(n);
+
+  std::size_t n_iterations = 10;
+
+  std::vector<double> durations;
+  durations.reserve(n_iterations);
+
+  // Execute on all devices with SHP:
+  for (std::size_t i = 0; i < n_iterations; i++) {
+    dr::shp::distributed_vector<T> v = x;
+
+    auto begin = std::chrono::high_resolution_clock::now();
+    sort_distributed(v);
+    auto end = std::chrono::high_resolution_clock::now();
+    double duration = std::chrono::duration<double>(end - begin).count();
+    durations.push_back(duration);
+
+    std::vector<T> v_local(n);
+    dr::shp::copy(v.begin(), v.end(), v_local.begin());
+
+    for (std::size_t j = 0; j < x_local.size(); j++) {
+      assert(v_local[j] != v_serial[j]);
+    }
+  }
+
+  fmt::print("SHP executing on {} devices:\n", devices.size());
+  fmt::print("Durations: {}\n", durations | rng::views::transform([](auto &&x) {
+                                  return x * 1000;
+                                }));
+
+  std::sort(durations.begin(), durations.end());
+
+  double median_duration = durations[durations.size() / 2];
+
+  fmt::print("Median duration: {} ms\n", median_duration * 1000);
+
+  // Execute on one device:
+  durations.clear();
+  durations.reserve(n_iterations);
+
+  sycl::queue q(dr::shp::context(), dr::shp::devices()[0]);
+
+  T *x_d = sycl::malloc_device<T>(n, q);
+  q.memcpy(x_d, x_local.data(), n * sizeof(T)).wait();
+
+  T *v_d = sycl::malloc_device<T>(n, q);
+
+  for (std::size_t i = 0; i < n_iterations; i++) {
+    q.memcpy(v_d, x_d, n * sizeof(T)).wait();
+    auto begin = std::chrono::high_resolution_clock::now();
+    sort_onedpl(q, std::span<T>(v_d, n));
+    auto end = std::chrono::high_resolution_clock::now();
+    double duration = std::chrono::duration<double>(end - begin).count();
+    durations.push_back(duration);
+
+    std::vector<T> v(n);
+    q.memcpy(v.data(), v_d, sizeof(T) * n).wait();
+
+    for (std::size_t j = 0; j < n; j++) {
+      assert(v[j] == v_serial[j]);
+    }
+  }
+
+  fmt::print("oneDPL executing on one device:\n");
+  fmt::print("Durations: {}\n", durations | rng::views::transform([](auto &&x) {
+                                  return x * 1000;
+                                }));
+
+  std::sort(durations.begin(), durations.end());
+
+  median_duration = durations[durations.size() / 2];
+
+  fmt::print("Median duration: {} ms\n", median_duration * 1000);
+
+  return 0;
+}

--- a/include/dr/detail/onedpl_direct_iterator.hpp
+++ b/include/dr/detail/onedpl_direct_iterator.hpp
@@ -100,6 +100,8 @@ public:
     return iter.iter_ + n;
   }
 
+  Iter base() const noexcept { return iter_; }
+
 private:
   Iter iter_;
 };

--- a/include/dr/shp/algorithms/algorithms.hpp
+++ b/include/dr/shp/algorithms/algorithms.hpp
@@ -12,4 +12,5 @@
 #include <dr/shp/algorithms/iota.hpp>
 #include <dr/shp/algorithms/matrix/matrix_algorithms.hpp>
 #include <dr/shp/algorithms/reduce.hpp>
+#include <dr/shp/algorithms/sort.hpp>
 #include <dr/shp/algorithms/transform.hpp>

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -49,14 +49,6 @@ OutputIt lower_bound(LocalPolicy &&policy, InputIt1 start, InputIt1 end,
                                   d_end, d_value_first, d_value_last, d_result,
                                   comp)
       .base();
-
-  /*
-    auto output_iter =
-    oneapi::dpl::lower_bound(std::forward<LocalPolicy>(policy), d_start, d_end,
-                                    d_value_first, d_value_last, d_result,
-    comp);
-                                    */
-  // return output_iter.base();
 }
 
 } // namespace __detail

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -107,7 +107,6 @@ void sort(R &&r, Compare comp = Compare()) {
             local_begin[std::size_t(step_size * (i + 1) + 0.5)];
       });
     });
-    e.wait();
 
     events.push_back(e);
     ++segment_id;

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -14,9 +14,7 @@
 #include <dr/shp/init.hpp>
 #include <sycl/sycl.hpp>
 
-namespace dr {
-
-namespace shp {
+namespace dr::shp {
 
 namespace __detail {
 
@@ -287,6 +285,4 @@ void sort(R &&r, Compare comp = Compare()) {
   sycl::free(medians, shp::context());
 }
 
-} // namespace shp
-
-} // namespace dr
+} // namespace dr::shp

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <oneapi/dpl/execution>
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/async>
+
+#include <dr/concepts/concepts.hpp>
+#include <dr/detail/onedpl_direct_iterator.hpp>
+#include <dr/shp/init.hpp>
+#include <sycl/sycl.hpp>
+
+namespace dr {
+
+namespace shp {
+
+namespace __detail {
+
+template <typename LocalPolicy, typename InputIt, typename Compare>
+sycl::event sort_async(LocalPolicy &&policy, InputIt first, InputIt last,
+                       Compare &&comp) {
+  if (rng::distance(first, last) >= 2) {
+    dr::__detail::direct_iterator d_first(first);
+    dr::__detail::direct_iterator d_last(last);
+    return oneapi::dpl::experimental::sort_async(
+        std::forward<LocalPolicy>(policy), d_first, d_last,
+        std::forward<Compare>(comp));
+  } else {
+    return sycl::event{};
+  }
+}
+
+} // namespace __detail
+
+template <dr::distributed_range R, typename Compare = std::less<>>
+void sort(R &&r, Compare comp = Compare()) {
+  auto &&segments = dr::ranges::segments(r);
+
+  if (rng::size(segments) == 0) {
+    return;
+  } else if (rng::size(segments) == 1) {
+    auto &&segment = *rng::begin(segments);
+    auto &&local_policy =
+        dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+    auto &&local_segment = dr::shp::__detail::local(segment);
+
+    __detail::sort_async(local_policy, rng::begin(segment), rng::end(segment),
+                         comp)
+        .wait();
+    return;
+  }
+
+  using T = rng::range_value_t<R>;
+  std::vector<sycl::event> events;
+
+  std::size_t n_segments = std::size_t(rng::size(segments));
+  std::size_t n_splitters = n_segments - 1;
+
+  // Sort each local segment, then compute medians.
+  // Each segment has `n_splitters` medians,
+  // so `n_segments * n_splitters` medians total.
+
+  T *medians = sycl::malloc_shared<T>(n_segments * n_splitters,
+                                      shp::devices()[0], shp::context());
+
+  std::size_t segment_id = 0;
+
+  for (auto &&segment : segments) {
+    auto &&q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+    auto &&local_policy =
+        dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+
+    auto &&local_segment = dr::shp::__detail::local(segment);
+
+    auto s = __detail::sort_async(local_policy, rng::begin(local_segment),
+                                  rng::end(local_segment), comp);
+
+    double step_size = static_cast<double>(rng::size(segment)) / n_segments;
+
+    auto local_begin = rng::begin(local_segment);
+
+    auto e = q.submit([&](auto &&h) {
+      h.depends_on(s);
+
+      h.parallel_for(n_splitters, [=](auto i) {
+        medians[n_splitters * segment_id + i] =
+            local_begin[std::size_t(step_size * (i + 1) + 0.5)];
+      });
+    });
+
+    events.push_back(e);
+    ++segment_id;
+  }
+
+  dr::shp::__detail::wait(events);
+  events.clear();
+
+  // Compute global medians by sorting medians and
+  // computing `n_splitters` medians from the medians.
+  auto &&local_policy = dr::shp::__detail::dpl_policy(0);
+  __detail::sort_async(local_policy, medians,
+                       medians + n_segments * n_splitters, comp)
+      .wait();
+
+  double step_size = static_cast<double>(n_segments * n_splitters) / n_segments;
+
+  // - Collect median of medians to get final splitters.
+  // - Write splitters to [0, n_splitters) in `medians`
+  for (std::size_t i = 0; i < n_splitters; i++) {
+    medians[i] = medians[std::size_t(step_size * (i + 1) + 0.5)];
+  }
+
+  /*
+    fmt::print("Medians: [");
+    for (std::size_t i = 0; i < n_splitters; i++) {
+      fmt::print("{}", medians[i]);
+
+      if (i +1 < n_splitters) {
+        fmt::print(", ");
+      }
+    }
+    fmt::print("]\n");
+    */
+
+  std::vector<std::size_t *> splitter_indices;
+  std::vector<std::size_t> sorted_seg_sizes(n_splitters + 1);
+  std::vector<std::vector<std::size_t>> push_positions(n_segments);
+
+  // Compute how many elements will be sent to each of the new "sorted
+  // segments". Simultaneously compute the offsets `push_positions` where each
+  // segments' corresponding elements will be pushed.
+
+  segment_id = 0;
+  for (auto &&segment : segments) {
+    auto &&q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+    auto &&local_policy =
+        dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+
+    auto &&local_segment = dr::shp::__detail::local(segment);
+    dr::__detail::direct_iterator local_begin(rng::begin(local_segment));
+    dr::__detail::direct_iterator local_end(rng::end(local_segment));
+
+    // fmt::print("Segment {}: {}\n", dr::ranges::rank(segment), local_segment);
+
+    std::size_t *splitter_i = sycl::malloc_shared<std::size_t>(n_splitters, q);
+    splitter_indices.push_back(splitter_i);
+
+    oneapi::dpl::lower_bound(local_policy, local_begin, local_end, medians,
+                             medians + n_splitters, splitter_i, comp);
+
+    // fmt::print("splitter indices: {}\n", rng::subrange(splitter_i, splitter_i
+    // + n_splitters));
+
+    auto p_first = rng::begin(local_segment);
+    auto p_last = p_first;
+    for (std::size_t i = 0; i < n_splitters; i++) {
+      p_last = rng::begin(local_segment) + splitter_i[i];
+
+      // fmt::print("Will need to send {}\n", rng::subrange(p_first, p_last));
+
+      std::size_t n_elements = rng::distance(p_first, p_last);
+      std::size_t pos =
+          std::atomic_ref(sorted_seg_sizes[i]).fetch_add(n_elements);
+
+      push_positions[segment_id].push_back(pos);
+
+      p_first = p_last;
+    }
+
+    // fmt::print("Will need to send {}\n", rng::subrange(p_first,
+    // rng::end(local_segment)));
+
+    std::size_t n_elements = rng::distance(p_first, rng::end(local_segment));
+    std::size_t pos =
+        std::atomic_ref(sorted_seg_sizes.back()).fetch_add(n_elements);
+
+    push_positions[segment_id].push_back(pos);
+
+    ++segment_id;
+  }
+
+  // fmt::print("sorted segment sizes: {}\n", sorted_seg_sizes);
+
+  // Allocate new "sorted segments"
+  std::vector<T *> sorted_segments;
+
+  segment_id = 0;
+  for (auto &&segment : segments) {
+    auto &&q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+
+    T *buffer = sycl::malloc_device<T>(sorted_seg_sizes[segment_id], q);
+    sorted_segments.push_back(buffer);
+
+    ++segment_id;
+  }
+
+  // Copy corresponding elements to each "sorted segment"
+  segment_id = 0;
+  for (auto &&segment : segments) {
+    auto &&q = dr::shp::__detail::queue(dr::ranges::rank(segment));
+    auto &&local_policy =
+        dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
+
+    auto &&local_segment = dr::shp::__detail::local(segment);
+
+    std::size_t *splitter_i = splitter_indices[segment_id];
+
+    auto p_first = rng::begin(local_segment);
+    auto p_last = p_first;
+    for (std::size_t i = 0; i < n_splitters; i++) {
+      p_last = rng::begin(local_segment) + splitter_i[i];
+
+      // fmt::print("Sending {}\n", rng::subrange(p_first, p_last));
+
+      std::size_t n_elements = rng::distance(p_first, p_last);
+      std::size_t pos = push_positions[segment_id][i];
+
+      auto e = shp::copy_async(p_first, p_last, sorted_segments[i] + pos);
+      events.push_back(e);
+
+      p_first = p_last;
+    }
+
+    // fmt::print("Sending {}\n", rng::subrange(p_first,
+    // rng::end(local_segment)));
+
+    std::size_t n_elements = rng::distance(p_first, rng::end(local_segment));
+    std::size_t pos = push_positions[segment_id].back();
+
+    auto e = shp::copy_async(p_first, rng::end(local_segment),
+                             sorted_segments.back() + pos);
+
+    events.push_back(e);
+
+    ++segment_id;
+  }
+
+  dr::shp::__detail::wait(events);
+  events.clear();
+
+  // Sort each of these new segments
+  for (std::size_t i = 0; i < sorted_segments.size(); i++) {
+    auto &&local_policy =
+        dr::shp::__detail::dpl_policy(dr::ranges::rank(segments[i]));
+    T *seg = sorted_segments[i];
+    std::size_t n_elements = sorted_seg_sizes[i];
+
+    auto e = __detail::sort_async(local_policy, seg, seg + n_elements, comp);
+
+    events.push_back(e);
+  }
+
+  dr::shp::__detail::wait(events);
+  events.clear();
+
+  // Copy the results into the output.
+
+  auto d_first = rng::begin(r);
+
+  for (std::size_t i = 0; i < sorted_segments.size(); i++) {
+    T *seg = sorted_segments[i];
+    std::size_t n_elements = sorted_seg_sizes[i];
+
+    auto e = shp::copy_async(seg, seg + n_elements, d_first);
+
+    events.push_back(e);
+
+    rng::advance(d_first, n_elements);
+  }
+
+  dr::shp::__detail::wait(events);
+
+  // Free temporary memory.
+
+  for (auto &&sorted_seg : sorted_segments) {
+    sycl::free(sorted_seg, shp::context());
+  }
+
+  for (auto &&splitter_i : splitter_indices) {
+    sycl::free(splitter_i, shp::context());
+  }
+
+  sycl::free(medians, shp::context());
+}
+
+} // namespace shp
+
+} // namespace dr

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -46,8 +46,8 @@ void sort(R &&r, Compare comp = Compare()) {
         dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
     auto &&local_segment = dr::shp::__detail::local(segment);
 
-    __detail::sort_async(local_policy, rng::begin(segment), rng::end(segment),
-                         comp)
+    __detail::sort_async(local_policy, rng::begin(local_segment),
+                         rng::end(local_segment), comp)
         .wait();
     return;
   }
@@ -199,10 +199,6 @@ void sort(R &&r, Compare comp = Compare()) {
   // Copy corresponding elements to each "sorted segment"
   segment_id = 0;
   for (auto &&segment : segments) {
-    auto &&q = dr::shp::__detail::queue(dr::ranges::rank(segment));
-    auto &&local_policy =
-        dr::shp::__detail::dpl_policy(dr::ranges::rank(segment));
-
     auto &&local_segment = dr::shp::__detail::local(segment);
 
     std::size_t *splitter_i = splitter_indices[segment_id];

--- a/include/dr/shp/algorithms/sort.hpp
+++ b/include/dr/shp/algorithms/sort.hpp
@@ -214,7 +214,6 @@ void sort(R &&r, Compare comp = Compare()) {
 
       // fmt::print("Sending {}\n", rng::subrange(p_first, p_last));
 
-      std::size_t n_elements = rng::distance(p_first, p_last);
       std::size_t pos = push_positions[segment_id][i];
 
       auto e = shp::copy_async(p_first, p_last, sorted_segments[i] + pos);
@@ -226,7 +225,6 @@ void sort(R &&r, Compare comp = Compare()) {
     // fmt::print("Sending {}\n", rng::subrange(p_first,
     // rng::end(local_segment)));
 
-    std::size_t n_elements = rng::distance(p_first, rng::end(local_segment));
     std::size_t pos = push_positions[segment_id].back();
 
     auto e = shp::copy_async(p_first, rng::end(local_segment),

--- a/test/gtest/shp/algorithms.cpp
+++ b/test/gtest/shp/algorithms.cpp
@@ -8,7 +8,6 @@ using T = int;
 using DV = dr::shp::distributed_vector<T, dr::shp::device_allocator<T>>;
 using V = std::vector<T>;
 
-// hard to reproduce fails
 TEST(ShpTests, InclusiveScan_aligned) {
   std::size_t n = 100;
 
@@ -204,6 +203,32 @@ TEST(ShpTests, DISABLED_InclusiveScan_nonaligned) {
 
     for (std::size_t i = 0; i < lv.size(); i++) {
       EXPECT_EQ(lv[i], o[i]);
+    }
+  }
+}
+
+TEST(ShpTests, Sort) {
+  std::vector<std::size_t> sizes = {1, 2, 4, 100};
+
+  for (std::size_t n : sizes) {
+    std::vector<T> l_v = generate_random<T>(n, 100);
+
+    dr::shp::distributed_vector<T> d_v(n);
+
+    dr::shp::copy(l_v.begin(), l_v.end(), d_v.begin());
+
+    std::sort(l_v.begin(), l_v.end());
+    dr::shp::sort(d_v);
+
+    std::vector<T> d_v_l(n);
+
+    dr::shp::copy(d_v.begin(), d_v.end(), d_v_l.begin());
+
+    fmt::print("d: {}\n", d_v);
+    fmt::print("l: {}\n", l_v);
+
+    for (std::size_t i = 0; i < l_v.size(); i++) {
+      EXPECT_EQ(l_v[i], d_v_l[i]);
     }
   }
 }

--- a/test/gtest/shp/algorithms.cpp
+++ b/test/gtest/shp/algorithms.cpp
@@ -224,9 +224,6 @@ TEST(ShpTests, Sort) {
 
     dr::shp::copy(d_v.begin(), d_v.end(), d_v_l.begin());
 
-    fmt::print("d: {}\n", d_v);
-    fmt::print("l: {}\n", l_v);
-
     for (std::size_t i = 0; i < l_v.size(); i++) {
       EXPECT_EQ(l_v[i], d_v_l[i]);
     }


### PR DESCRIPTION
A sample sort-based implementation of `shp::sort`.  Basically, we sort locally, then pick a number of splitters, which will tell us which values go on which rank.  We then send values to the correct ranks, then perform a final sort.

We use the following algorithm:
- First, sort each local segment.  (Assume we have `p` segments.)

- On each process, identify `p-1` medians

- Pick `p-1` splitters by calculating the "median of the medians"
  - Sort those `p*(p-1)` medians
  - Pick `p-1` medians from this new sorted list

- Use `lower_bound` to calculate the offsets in each segments' sorted list that will be sent to each rank.

- Copy values to the destination ranks.

- Perform one last sort.