### PR TITLE
new mhp zip view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CXX: clang++-15
-      CC: clang-15
     steps:
     - uses: actions/checkout@v3
     - name: Apt installs
@@ -47,10 +46,6 @@ jobs:
           ${{ env.TBB }}
     - name: Build & test
       run: |
-        # Cmake needs this to find MPI when using versioned clangs
-        alias clang=clang-15
-        alias clang++=clang++-15
-
         source /opt/intel/oneapi/setvars.sh
         cmake -B build
         make -j 2 -C build all test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Apt installs
-      run: sudo apt install -y clang-15 libopenmpi-dev
+      run: sudo apt install -y clang-15
     - uses: rscohn2/setup-oneapi@v0
       with:
         components: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,12 @@ jobs:
   clang:
     runs-on: ubuntu-latest
     env:
-      CXX: clang++
+      CXX: clang++-15
+      CC: clang-15
     steps:
     - uses: actions/checkout@v3
+    - name: Install Clang-15
+      run: sudo apt install -y clang-15
     - uses: rscohn2/setup-oneapi@v0
       with:
         components: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
           ${{ env.TBB }}
     - name: Build & test
       run: |
+        # Cmake needs this to find MPI when using versioned clangs
+        alias clang=clang-15
+        alias clang++=clang++-15
+
         source /opt/intel/oneapi/setvars.sh
         cmake -B build
         make -j 2 -C build all test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       CC: clang-15
     steps:
     - uses: actions/checkout@v3
-    - name: Install Clang-15
-      run: sudo apt install -y clang-15
+    - name: Apt installs
+      run: sudo apt install -y clang-15 libopenmpi-dev
     - uses: rscohn2/setup-oneapi@v0
       with:
         components: |

--- a/doc/spec/source/algorithms/copy.rst
+++ b/doc/spec/source/algorithms/copy.rst
@@ -16,7 +16,7 @@ Synopsis
 MHP
 ---
 
-.. doxygenfunction:: dr::mhp::copy(dr::distributed_contiguous_range auto &&in, dr::distributed_iterator auto out)
+.. doxygenfunction:: dr::mhp::copy(dr::distributed_range auto &&in, dr::distributed_iterator auto out)
    :outline:
 .. doxygenfunction:: dr::mhp::copy(DI_IN &&first, DI_IN &&last, dr::distributed_iterator auto &&out)
    :outline:

--- a/doc/spec/source/concepts.rst
+++ b/doc/spec/source/concepts.rst
@@ -8,8 +8,8 @@
 Concepts
 ========
 
-dr::remote_contiguous_iterator
-===============================
+``remote_contiguous_iterator``
+==============================
 
 .. doxygenconcept:: dr::remote_contiguous_iterator
 
@@ -46,8 +46,8 @@ Instantiations of `remote_ptr`, `device_ptr`, and `BCL::GlobalPtr` should all
 fulfill ``remote_contiguous_iterator``.
 
 
-dr::remote_contiguous_range
-============================
+``remote_contiguous_range``
+===========================
 
 .. doxygenconcept:: dr::remote_contiguous_range
 
@@ -83,8 +83,8 @@ with the same rank, and ``[begin().local(), end().local())`` should form a
 contiguous range referencing the same memory, but locally. Not quite sure how
 to express that concisely.
 
-dr::distributed_contiguous_range
-=================================
+``distributed_contiguous_range``
+================================
 
 .. doxygenconcept:: dr::distributed_contiguous_range
 

--- a/include/dr/detail/communicator.hpp
+++ b/include/dr/detail/communicator.hpp
@@ -117,10 +117,7 @@ public:
     MPI_Win_create(data, size, 1, MPI_INFO_NULL, comm.mpi_comm(), &win_);
   }
 
-  void free() {
-    dr::drlog.debug("freeing {}\n", win_);
-    MPI_Win_free(&win_);
-  }
+  void free() { MPI_Win_free(&win_); }
 
   bool operator==(const rma_window other) const noexcept {
     return this->win_ == other.win_;
@@ -153,10 +150,7 @@ public:
     MPI_Wait(&request, MPI_STATUS_IGNORE);
   }
 
-  void fence() const {
-    dr::drlog.debug("fence {}\n", win_);
-    MPI_Win_fence(0, win_);
-  }
+  void fence() const { MPI_Win_fence(0, win_); }
 
   void flush(std::size_t rank) const {
     drlog.debug("flush:: rank: {}\n", rank);

--- a/include/dr/mhp/algorithms/algorithms.hpp
+++ b/include/dr/mhp/algorithms/algorithms.hpp
@@ -44,8 +44,7 @@ void fill(DI first, DI last, auto value) {
 //
 
 /// Copy
-void copy(dr::distributed_contiguous_range auto &&in,
-          dr::distributed_iterator auto out) {
+void copy(dr::distributed_range auto &&in, dr::distributed_iterator auto out) {
   if (aligned(in, out)) {
     dr::drlog.debug("copy: parallel execution\n");
     for (const auto &&[in_seg, out_seg] :

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -153,7 +153,7 @@ public:
   auto operator[](difference_type n) const { return *(begin() + n); }
 
 private:
-  DV *dv_;
+  DV *dv_ = nullptr;
   std::size_t segment_index_;
   std::size_t size_;
 }; // dv_segment
@@ -217,8 +217,11 @@ public:
     }
 
     bool operator==(iterator other) const {
-      assert(parent_ == other.parent_);
-      return offset_ == other.offset_;
+      if (parent_ == nullptr || other.parent_ == nullptr) {
+        return false;
+      } else {
+        return offset_ == other.offset_;
+      }
     }
     auto operator<=>(iterator other) const {
       assert(parent_ == other.parent_);
@@ -243,7 +246,7 @@ public:
     }
 
   private:
-    const distributed_vector *parent_;
+    const distributed_vector *parent_ = nullptr;
     difference_type offset_;
   };
 

--- a/include/dr/mhp/global.hpp
+++ b/include/dr/mhp/global.hpp
@@ -47,7 +47,6 @@ inline auto use_sycl() { return __detail::gcontext()->use_sycl_; }
 inline void fence() {
   dr::drlog.debug("fence\n");
   for (auto win : __detail::gcontext()->wins_) {
-    dr::drlog.debug("  win: {}\n", win);
     MPI_Win_fence(0, win);
   }
 }

--- a/include/dr/mhp/views/enumerate.hpp
+++ b/include/dr/mhp/views/enumerate.hpp
@@ -30,8 +30,8 @@ public:
     requires(rng::sized_range<R>)
   auto operator()(R &&r) const {
     using W = std::uint32_t;
-    return mhp::zip_view(rng::views::iota(W(0), W(rng::distance(r))),
-                         std::forward<R>(r));
+    return mhp::views::zip(rng::views::iota(W(0), W(rng::distance(r))),
+                           std::forward<R>(r));
   }
 
   template <rng::viewable_range R>

--- a/include/dr/mhp/views/enumerate.hpp
+++ b/include/dr/mhp/views/enumerate.hpp
@@ -30,7 +30,7 @@ public:
     requires(rng::sized_range<R>)
   auto operator()(R &&r) const {
     using W = std::uint32_t;
-    return mhp::views::zip(rng::views::iota(W(0), W(rng::distance(r))),
+    return mhp::views::zip(mhp::views::iota(W(0), W(rng::distance(r))),
                            std::forward<R>(r));
   }
 

--- a/include/dr/mhp/views/segmented.hpp
+++ b/include/dr/mhp/views/segmented.hpp
@@ -42,6 +42,16 @@ private:
   SegTplIter tpl_cur_, tpl_end_;
 };
 
+//
+// Some distributed algorithms need an iota_view as an operand. An
+// iota_view does not depend on external data and can be segmented as
+// needed. The segmented_view creates segments for a range using the
+// segments of another range. It can be used to create segments for an
+// iota_view, using the segments of a distributed_range.
+//
+// It should be usable if you have a range that is local and
+// replicated across all processes, but that is not tested.
+//
 template <rng::random_access_range R, rng::forward_range SegTpl>
 class segmented_view : public rng::view_base {
 public:

--- a/include/dr/mhp/views/segmented.hpp
+++ b/include/dr/mhp/views/segmented.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace dr::mhp {
+
+template <typename BaseIter, typename SegTplIter>
+class segmented_view_iterator {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using difference_type = rng::iter_difference_t<SegTplIter>;
+  using value_type = dr::remote_subrange<BaseIter>;
+
+  segmented_view_iterator() {}
+  segmented_view_iterator(BaseIter base_begin, SegTplIter tpl_begin,
+                          SegTplIter tpl_end)
+      : base_cur_(base_begin), tpl_cur_(tpl_begin), tpl_end_(tpl_end) {}
+
+  auto operator==(segmented_view_iterator other) const {
+    return tpl_cur_ == other.tpl_cur_;
+  }
+  auto &operator++() {
+    base_cur_ += rng::size(*tpl_cur_);
+    tpl_cur_++;
+    return *this;
+  }
+  auto operator++(int) {
+    auto iter(*this);
+    base_cur_ += rng::size(*tpl_cur_);
+    tpl_cur_++;
+    return iter;
+  }
+  auto operator*() const {
+    return dr::remote_subrange(base_cur_, base_cur_ + rng::size(*tpl_cur_),
+                               dr::ranges::rank(*tpl_cur_));
+  }
+
+private:
+  BaseIter base_cur_;
+  SegTplIter tpl_cur_, tpl_end_;
+};
+
+template <rng::random_access_range R, rng::forward_range SegTpl>
+class segmented_view : public rng::view_base {
+public:
+  template <typename V1, typename V2>
+  segmented_view(V1 &&r, V2 &&tpl)
+      : base_(rng::views::all(std::forward<V1>(r))),
+        segments_tpl_(rng::views::all(std::forward<V2>(tpl))) {}
+
+  auto begin() const {
+    return segmented_view_iterator(rng::begin(base_), rng::begin(segments_tpl_),
+                                   rng::end(segments_tpl_));
+  }
+  auto end() const {
+    return segmented_view_iterator(rng::begin(base_), rng::end(segments_tpl_),
+                                   rng::end(segments_tpl_));
+  }
+
+private:
+  rng::views::all_t<R> base_;
+  rng::views::all_t<SegTpl> segments_tpl_;
+};
+
+template <typename R, typename Seg>
+segmented_view(R &&r, Seg &&seg)
+    -> segmented_view<rng::views::all_t<R>, rng::views::all_t<Seg>>;
+
+namespace views {
+
+/// Zip
+template <typename R, typename Seg> auto segmented(R &&r, Seg &&seg) {
+  return segmented_view(std::forward<R>(r), std::forward<Seg>(seg));
+}
+
+} // namespace views
+
+} // namespace dr::mhp

--- a/include/dr/mhp/views/views.hpp
+++ b/include/dr/mhp/views/views.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <dr/detail/ranges_shim.hpp>
+#include <dr/views/iota.hpp>
+#include <dr/views/transform.hpp>
 
 namespace dr::mhp {
 
@@ -16,7 +18,8 @@ template <typename R> auto local_segments(R &&dr) {
   };
   // Convert from remote iter to local iter
   auto local_iter = [](const auto &segment) {
-    return dr::ranges::local(segment);
+    auto b = dr::ranges::local(rng::begin(segment));
+    return rng::subrange(b, b + rng::distance(segment));
   };
   return dr::ranges::segments(std::forward<R>(dr)) |
          rng::views::filter(is_local) | rng::views::transform(local_iter);
@@ -28,8 +31,8 @@ namespace dr::mhp::views {
 
 inline constexpr auto all = rng::views::all;
 inline constexpr auto drop = rng::views::drop;
+inline constexpr auto iota = dr::views::iota;
 inline constexpr auto take = rng::views::take;
 inline constexpr auto transform = dr::views::transform;
-inline constexpr auto iota = rng::views::iota;
 
 } // namespace dr::mhp::views

--- a/include/dr/mhp/views/zip.hpp
+++ b/include/dr/mhp/views/zip.hpp
@@ -9,276 +9,262 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 #include <dr/detail/ranges_shim.hpp>
 #include <dr/mhp/alignment.hpp>
+#include <dr/mhp/views/segmented.hpp>
+
+namespace dr::mhp::__detail {
+
+template <typename R>
+concept zipable = rng::random_access_range<R> && rng::common_range<R>;
+
+} // namespace dr::mhp::__detail
 
 namespace dr::mhp {
 
-template <typename T>
-concept has_rank = requires(T &t) { dr::ranges::rank(t); };
-
-template <typename T>
-concept tuple_has_rank = []<std::size_t... N>(std::index_sequence<N...>) {
-  return (has_rank<typename std::tuple_element<N, T>::type> || ...);
-}(std::make_index_sequence<std::tuple_size_v<T>>());
-
-template <typename T>
-concept tuple_has_distributed_range =
-    []<std::size_t... N>(std::index_sequence<N...>) {
-      return (dr::distributed_range<typename std::tuple_element<N, T>::type> ||
-              ...);
-    }(std::make_index_sequence<std::tuple_size_v<T>>());
-
-template <rng::viewable_range... R> class zip_view;
+template <__detail::zipable... Rs> class zip_view;
 
 namespace views {
 
-template <rng::viewable_range... R> auto zip(R &&...r) {
-  return zip_view(std::forward<R>(r)...);
+template <typename... Rs> auto zip(Rs &&...rs) {
+  return zip_view(std::forward<Rs>(rs)...);
 }
 
 } // namespace views
 
-template <rng::viewable_range... R> class zip_view {
-private:
-  using rng_zip = rng::zip_view<R...>;
-  using rng_zip_iterator = rng::iterator_t<rng_zip>;
-  using base_type = std::tuple<R...>;
-  using difference_type = std::iter_difference_t<rng_zip_iterator>;
+namespace __detail {
 
-public:
-  // Wrap the iterator for rng::zip
-  class zip_iterator {
-  public:
-    using iterator_category = std::random_access_iterator_tag;
-    using value_type = std::iter_value_t<rng_zip_iterator>;
-    using difference_type = std::iter_difference_t<rng_zip_iterator>;
+template <typename T>
+concept is_distributed = distributed_range<std::remove_cvref_t<T>> ||
+                         distributed_iterator<std::remove_cvref_t<T>>;
 
-    zip_iterator() {}
-    zip_iterator(const zip_view *parent, difference_type offset)
-        : parent_(parent), offset_(offset) {}
+template <typename T, typename... Rest>
+inline auto select_segments(T &&t, Rest &&...rest) {
+  if constexpr (is_distributed<T>) {
+    return dr::ranges::segments(std::forward<T>(t));
+  } else {
+    return select_segments(std::forward<Rest>(rest)...);
+  }
+}
 
-    auto operator+(difference_type n) const {
-      return zip_iterator(parent_, offset_ + n);
-    }
-    friend auto operator+(difference_type n, const zip_iterator &other) {
-      return other + n;
-    }
-    auto operator-(difference_type n) const {
-      return zip_iterator(parent_, offset_ - n);
-    }
-    auto operator-(zip_iterator other) const { return offset_ - other.offset_; }
+template <typename T, typename Seg> inline auto tpl_segments(T &&t, Seg &&tpl) {
+  if constexpr (is_distributed<T>) {
+    return dr::ranges::segments(std::forward<T>(t));
+  } else if constexpr (rng::forward_range<T>) {
+    return views::segmented(std::forward<T>(t), std::forward<Seg>(tpl));
+  } else if constexpr (rng::forward_iterator<T>) {
+    return views::segmented(rng::subrange(std::forward<T>(t), T{}),
+                            std::forward<Seg>(tpl));
+  }
+}
 
-    auto &operator+=(difference_type n) {
-      offset_ += n;
-      return *this;
-    }
-    auto &operator-=(difference_type n) {
-      offset_ -= n;
-      return *this;
-    }
-    auto &operator++() {
-      offset_++;
-      return *this;
-    }
-    auto operator++(int) {
-      auto old = *this;
-      offset_++;
-      return old;
-    }
-    auto &operator--() {
-      offset_--;
-      return *this;
-    }
-    auto operator--(int) {
-      auto old = *this;
-      offset_--;
-      return old;
-    }
-
-    auto operator==(zip_iterator other) const {
-      assert(parent_ == other.parent_);
-      return offset_ == other.offset_;
-    }
-    auto operator<=>(zip_iterator other) const {
-      assert(parent_ == other.parent_);
-      return offset_ <=> other.offset_;
-    }
-
-    // Underlying iterator does not return a reference
-    auto operator*() const {
-      return *(rng::begin(parent_->rng_zip_) + offset_);
-    }
-    auto operator[](difference_type n) const { return *(*this + n); }
-
-    //
-    // Support for distributed ranges
-    //
-    // distributed iterator provides segments
-    // remote iterator provides local
-    //
-    auto segments()
-      requires(tuple_has_distributed_range<base_type>)
-    {
-      return dr::__detail::drop_segments(parent_->segments(), offset_);
-    }
-    auto local() {
-      auto remainder = rng::distance(*parent_) - offset_;
-      auto offset = offset_;
-      auto localize = [remainder, offset](auto... base_iters) {
-        // for each base iter, construct a range that covers the rest
-        // of the segment, and then zip the ranges together. Return
-        // the begin iterator of the zip.
-        //
-        // The types of this zip_view is different from the containing
-        // zip_view, so use rng::zip_view to force template argument
-        // type deduction.
-        return rng::begin(rng::zip_view(rng::views::counted(
-            base_local(base_iters) + offset, remainder)...));
-      };
-      return std::apply(localize, rng::begin(*parent_).base());
-    }
-
-  private:
-    // return a tuple of iterators for the components
-    auto base() {
-      auto advance = [this](auto &&...base_ranges) {
-        return std::tuple((rng::begin(base_ranges) + this->offset_)...);
-      };
-      return std::apply(advance, parent_->base_);
-    }
-
-    // If it is not a remote iterator, assume it is a local iterator
-    auto static base_local(auto iter) { return iter; }
-
-    auto static base_local(dr::remote_iterator auto iter) {
-      return dr::ranges::local(iter);
-    }
-
-    const zip_view *parent_;
-    difference_type offset_;
+template <typename Base> auto base_to_segments(Base &&base) {
+  // Given segments, return elementwise zip
+  auto zip_segments = [](auto &&...segments) {
+    return views::zip(segments...);
   };
 
-  zip_view(R... r)
-      : rng_zip_(rng::views::all(r)...), base_(rng::views::all(r)...) {
-    compute_segment_descriptors(std::forward<R>(r)...);
+  // Given a tuple of segments, return a single segment by doing
+  // elementwise zip
+  auto zip_segment_tuple = [zip_segments](auto &&v) {
+    return std::apply(zip_segments, v);
+  };
+
+  // Given base ranges, return segments
+  auto bases_to_segments = [zip_segment_tuple](auto &&...bases) {
+    bool is_aligned = aligned(bases...);
+    auto tpl = select_segments(bases...);
+    return rng::views::zip(tpl_segments(bases, tpl)...) |
+           rng::views::transform(zip_segment_tuple) |
+           rng::views::filter([is_aligned](auto &&v) { return is_aligned; });
+  };
+
+  return std::apply(bases_to_segments, base);
+}
+
+} // namespace __detail
+
+template <std::random_access_iterator RngIter,
+          std::random_access_iterator... BaseIters>
+class zip_iterator {
+public:
+  using value_type = rng::iter_value_t<RngIter>;
+  using difference_type = rng::iter_difference_t<RngIter>;
+
+  using iterator_category = std::random_access_iterator_tag;
+
+  zip_iterator() {}
+  zip_iterator(RngIter rng_iter, BaseIters... base_iters)
+      : rng_iter_(rng_iter), base_(base_iters...) {}
+
+  auto operator+(difference_type n) const {
+    auto iter(*this);
+    iter.rng_iter_ += n;
+    iter.offset_ += n;
+    return iter;
+  }
+  friend auto operator+(difference_type n, const zip_iterator &other) {
+    return other + n;
+  }
+  auto operator-(difference_type n) const {
+    auto iter(*this);
+    iter.rng_iter_ -= n;
+    iter.offset_ -= n;
+    return iter;
+  }
+  auto operator-(zip_iterator other) const {
+    return rng_iter_ - other.rng_iter_;
   }
 
-  auto begin() const { return zip_iterator(this, 0); }
-  auto end() const { return zip_iterator(this, rng::distance(rng_zip_)); }
-  auto size() const { return rng::distance(rng_zip_); }
-  auto operator[](difference_type n) const { return begin()[n]; }
+  auto &operator+=(difference_type n) {
+    rng_iter_ += n;
+    offset_ += n;
+    return *this;
+  }
+  auto &operator-=(difference_type n) {
+    rng_iter_ -= n;
+    offset_ -= n;
+    return *this;
+  }
+  auto &operator++() {
+    rng_iter_++;
+    offset_++;
+    return *this;
+  }
+  auto operator++(int) {
+    auto iter(*this);
+    rng_iter_++;
+    offset_++;
+    return iter;
+  }
+  auto &operator--() {
+    rng_iter_--;
+    offset_--;
+    return *this;
+  }
+  auto operator--(int) {
+    auto iter(*this);
+    rng_iter_--;
+    offset_--;
+    return iter;
+  }
+
+  auto operator==(zip_iterator other) const {
+    return rng_iter_ == other.rng_iter_;
+  }
+  auto operator<=>(zip_iterator other) const {
+    return offset_ <=> other.offset_;
+  }
+
+  // Underlying zip_iterator does not return a reference
+  auto operator*() const { return *rng_iter_; }
+  auto operator[](difference_type n) const { return rng_iter_[n]; }
 
   //
-  // Support for distributed ranges
-  //
-  // distributed range provides segments
-  // remote range provides rank
+  // Distributed Ranges support
   //
   auto segments() const
-    requires(tuple_has_distributed_range<base_type>)
+    requires(distributed_iterator<BaseIters> || ...)
   {
-    // requires at least one distributed range in base
-    auto zip_segments = [this](auto &&...base) {
-      auto zip_segment = [](auto &&v) {
-        auto zip_ranges = [](auto &&...refs) { return views::zip(refs...); };
-        return std::apply(zip_ranges, v);
-      };
-
-      auto z = rng::views::zip(this->base_segments(base)...) |
-               rng::views::transform(zip_segment);
-      if (aligned(base...)) {
-        return z;
-      } else {
-        return decltype(z){};
-      }
-    };
-
-    return std::apply(zip_segments, base_);
+    return dr::__detail::drop_segments(__detail::base_to_segments(base_),
+                                       offset_);
   }
 
   auto rank() const
-    requires(tuple_has_rank<base_type>)
+    requires(remote_iterator<BaseIters> || ...)
   {
-    auto select = [](auto &&...v) { return select_rank(v...); };
-    return std::apply(select, base_);
+    return dr::ranges::rank(std::get<0>(base_));
+  }
+
+  auto local() const
+    requires(remote_iterator<BaseIters> || ...)
+  {
+    // Create a temporary zip_view and return the iterator. This code
+    // assumes the iterator is valid even if the underlying zip_view
+    // is destroyed.
+    auto zip = [this]<typename... Iters>(Iters &&...iters) {
+      return rng::begin(rng::views::zip(
+          rng::subrange(base_local(std::forward<Iters>(iters)) + this->offset_,
+                        decltype(base_local(iters)){})...));
+    };
+
+    return std::apply(zip, base_);
   }
 
 private:
-  //
-  // Support for distributed ranges
-  //
-  struct segment_descriptor {
-    std::size_t offset, size;
-  };
+  // If it is not a remote iterator, assume it is a local iterator
+  auto static base_local(auto iter) { return iter; }
 
-  template <typename... V> void compute_segment_descriptors(V &&...v) {}
-
-  template <typename... V>
-  void compute_segment_descriptors(V &&...v)
-    requires(dr::distributed_range<V> || ...)
-  {
-    auto segments = dr::ranges::segments(select_dist_range(v...));
-    segment_descriptor descriptor{0, 0};
-    for (auto segment : segments) {
-      descriptor.size = rng::distance(segment);
-      segment_descriptors_.emplace_back(descriptor);
-      descriptor.offset += descriptor.size;
-    }
+  auto static base_local(dr::remote_iterator auto iter) {
+    return dr::ranges::local(iter);
   }
 
-  static auto select_rank(auto &&v, auto &&...rest) {
-    if constexpr (has_rank<decltype(v)>) {
-      return dr::ranges::rank(v);
-    } else {
-      return select_rank(rest...);
-    }
-  }
-
-  static auto select_dist_range(auto &&v, auto &&...rest) {
-    if constexpr (dr::distributed_range<decltype(v)>) {
-      return rng::views::all(v);
-    } else {
-      return select_dist_range(rest...);
-    }
-  }
-
-  template <dr::distributed_range V> auto base_segments(V &&base) const {
-    return dr::ranges::segments(base);
-  }
-
-  // If this is not a distributed range, then assume it is local and
-  // segment according to segment_descriptors
-  template <rng::range V> auto base_segments(V &&base) const {
-    auto make_segment = [base](const segment_descriptor &d) {
-      return rng::subrange(rng::begin(base) + d.offset,
-                           rng::begin(base) + d.offset + d.size);
-    };
-
-    return segment_descriptors_ | rng::views::transform(make_segment);
-  }
-
-  // Expensive to copy if there are many segments
-  std::vector<segment_descriptor> segment_descriptors_;
-
-  rng_zip rng_zip_;
-  base_type base_;
+  RngIter rng_iter_;
+  std::tuple<BaseIters...> base_;
+  difference_type offset_ = 0;
 };
 
-template <rng::viewable_range... R>
-zip_view(R &&...r) -> zip_view<rng::views::all_t<R>...>;
+template <__detail::zipable... Rs> class zip_view : public rng::view_base {
+private:
+  using rng_zip = rng::zip_view<Rs...>;
+  using rng_zip_iterator = rng::iterator_t<rng_zip>;
+  using difference_type = std::iter_difference_t<rng_zip_iterator>;
+
+public:
+  zip_view(Rs... rs)
+      : rng_zip_(rng::views::all(rs)...), base_(rng::views::all(rs)...) {}
+
+  auto begin() const {
+    auto make_begin = [this](auto &&...bases) {
+      return zip_iterator(rng::begin(this->rng_zip_), rng::begin(bases)...);
+    };
+    return std::apply(make_begin, base_);
+  }
+  auto end() const
+    requires(rng::common_range<rng_zip>)
+  {
+    auto make_end = [this](auto &&...bases) {
+      return zip_iterator(rng::end(this->rng_zip_), rng::end(bases)...);
+    };
+    return std::apply(make_end, base_);
+  }
+  auto size() const { return rng::size(rng_zip_); }
+  auto operator[](difference_type n) const { return rng_zip_[n]; }
+
+  auto base() const { return base_; }
+
+  //
+  // Distributed Ranges support
+  //
+  auto segments() const
+    requires(distributed_range<Rs> || ...)
+  {
+    return __detail::base_to_segments(base_);
+  }
+
+  auto rank() const
+    requires(remote_range<Rs> || ...)
+  {
+    return dr::ranges::rank(std::get<0>(base_));
+  }
+
+  auto local() const
+    requires(remote_range<Rs> || ...)
+  {
+    auto zip = []<typename... Vs>(Vs &&...bases) {
+      return rng::views::zip(dr::ranges::local(std::forward<Vs>(bases))...);
+    };
+
+    return std::apply(zip, base_);
+  }
+
+private:
+  rng_zip rng_zip_;
+  std::tuple<rng::views::all_t<Rs>...> base_;
+};
+
+template <typename... Rs>
+zip_view(Rs &&...rs) -> zip_view<rng::views::all_t<Rs>...>;
 
 } // namespace dr::mhp
-
-namespace DR_RANGES_NAMESPACE {} // namespace DR_RANGES_NAMESPACE
-
-#if !defined(DR_SPEC)
-
-// Needed to satisfy rng::viewable_range
-template <rng::random_access_range... V>
-inline constexpr bool rng::enable_borrowed_range<dr::mhp::zip_view<V...>> =
-    true;
-
-#endif

--- a/include/dr/shp/algorithms/iota.hpp
+++ b/include/dr/shp/algorithms/iota.hpp
@@ -4,30 +4,14 @@
 
 #pragma once
 
-#include <dr/detail/ranges_shim.hpp>
 #include <limits>
 
 #include <dr/concepts/concepts.hpp>
+#include <dr/detail/ranges_shim.hpp>
 #include <dr/shp/algorithms/for_each.hpp>
+#include <dr/views/iota.hpp>
 
 namespace dr::shp {
-
-namespace views {
-
-struct iota_fn_ {
-  template <std::integral W> auto operator()(W value) const {
-    return rng::views::iota(value, std::numeric_limits<W>::max());
-  }
-
-  template <std::integral W, std::integral Bound>
-  auto operator()(W value, Bound bound) {
-    return rng::views::iota(value, W(bound));
-  }
-};
-
-inline constexpr auto iota = iota_fn_{};
-
-} // namespace views
 
 template <dr::distributed_range R, std::integral T> void iota(R &&r, T value) {
   auto iota_view = rng::views::iota(value, T(value + rng::distance(r)));

--- a/include/dr/shp/views/views.hpp
+++ b/include/dr/shp/views/views.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <dr/shp/views/standard_views.hpp>
+#include <dr/views/iota.hpp>
+#include <dr/views/transform.hpp>
 #include <dr/views/views.hpp>
 
 namespace dr::shp::views {
@@ -12,6 +14,8 @@ namespace dr::shp::views {
 inline constexpr auto all = rng::views::all;
 
 inline constexpr auto drop = rng::views::drop;
+
+inline constexpr auto iota = dr::views::iota;
 
 inline constexpr auto take = rng::views::take;
 

--- a/include/dr/views/iota.hpp
+++ b/include/dr/views/iota.hpp
@@ -17,7 +17,7 @@ struct iota_fn_ {
   }
 
   template <std::integral W, std::integral Bound>
-  auto operator()(W value, Bound bound) {
+  auto operator()(W value, Bound bound) const {
     return rng::views::iota(value, W(bound));
   }
 };

--- a/include/dr/views/iota.hpp
+++ b/include/dr/views/iota.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace dr::views {
+
+//
+// range-v3 iota uses sentinels that are not the same type as the
+// iterator. A zip that uses an iota has the same issue. Make our own.
+//
+
+struct iota_fn_ {
+  template <std::integral W> auto operator()(W value) const {
+    return rng::views::iota(value, std::numeric_limits<W>::max());
+  }
+
+  template <std::integral W, std::integral Bound>
+  auto operator()(W value, Bound bound) {
+    return rng::views::iota(value, W(bound));
+  }
+};
+
+inline constexpr auto iota = iota_fn_{};
+
+} // namespace dr::views

--- a/include/dr/views/transform.hpp
+++ b/include/dr/views/transform.hpp
@@ -139,9 +139,9 @@ public:
   {
     auto fn = fn_;
     return dr::ranges::segments(base_) |
-           rng::views::transform([fn](auto &&segment) {
+           rng::views::transform([fn]<typename T>(T &&segment) {
              return transform_view<rng::views::all_t<decltype(segment)>, F>(
-                 segment, fn);
+                 std::forward<T>(segment), fn);
            });
   }
 

--- a/scripts/dr-style.py
+++ b/scripts/dr-style.py
@@ -116,12 +116,8 @@ include_rules = [
         'use rng::end()',
     ),
     (
-        r'rng::size\(',
-        'use rng::distance()',
-    ),
-    (
         r'\.size\(\)',
-        'use rng::distance()',
+        'use rng::size()',
     ),
     (
         r'std::begin\(',
@@ -134,6 +130,10 @@ include_rules = [
     (
         r'std::distance\(',
         'use rng::distance()',
+    ),
+    (
+        r'std::size\(',
+        'use rng::size()',
     ),
 ]
 include_rules_compiled = []

--- a/test/gtest/common/zip.cpp
+++ b/test/gtest/common/zip.cpp
@@ -4,6 +4,10 @@
 
 #include "xhp-tests.hpp"
 
+template <typename... Rs> auto test_zip(Rs &&...rs) {
+  return xhp::views::zip(std::forward<Rs>(rs)...);
+}
+
 // Fixture
 template <typename T> class Zip : public testing::Test {
 public:
@@ -11,55 +15,11 @@ public:
 
 TYPED_TEST_SUITE(Zip, AllTypes);
 
-// Try 1, 2, 3 to check pair/tuple issues
-TYPED_TEST(Zip, Local1) {
-  Ops1<TypeParam> ops(10);
-
-  EXPECT_EQ(rng::views::zip(ops.vec), xhp::views::zip(ops.vec));
-}
-
-TYPED_TEST(Zip, Local2) {
-  Ops2<TypeParam> ops(10);
-
-  EXPECT_EQ(rng::views::zip(ops.vec0, ops.vec1),
-            xhp::views::zip(ops.vec0, ops.vec1));
-}
-
-TYPED_TEST(Zip, Local3) {
-  Ops3<TypeParam> ops(10);
-
-  EXPECT_EQ(rng::views::zip(ops.vec0, ops.vec1, ops.vec2),
-            xhp::views::zip(ops.vec0, ops.vec1, ops.vec2));
-}
-
-TYPED_TEST(Zip, Local3Distance) {
-  Ops3<TypeParam> ops(10);
-
-  EXPECT_EQ(rng::distance(rng::views::zip(ops.vec0, ops.vec1, ops.vec2)),
-            rng::distance(xhp::views::zip(ops.vec0, ops.vec1, ops.vec2)));
-}
-
-TYPED_TEST(Zip, Local2Mutate) {
-  Ops2<TypeParam> rops(10);
-  Ops2<TypeParam> xops(10);
-
-  auto r = rng::views::zip(rops.vec0, rops.vec1);
-  auto x = rng::views::zip(xops.vec0, xops.vec1);
-  auto n2 = [](auto v) {
-    std::get<0>(v) += 1;
-    std::get<1>(v) = -std::get<1>(v);
-  };
-  rng::for_each(r, n2);
-  rng::for_each(x, n2);
-  EXPECT_EQ(rops.vec0, xops.vec0);
-  EXPECT_EQ(rops.vec1, xops.vec1);
-}
-
 TYPED_TEST(Zip, Dist1) {
   Ops1<TypeParam> ops(10);
 
   auto local = rng::views::zip(ops.vec);
-  auto dist = xhp::views::zip(ops.dist_vec);
+  auto dist = test_zip(ops.dist_vec);
   static_assert(compliant_view<decltype(dist)>);
   EXPECT_TRUE(check_view(local, dist));
 }
@@ -68,7 +28,7 @@ TYPED_TEST(Zip, Dist2) {
   Ops2<TypeParam> ops(10);
 
   auto local = rng::views::zip(ops.vec0, ops.vec1);
-  auto dist = xhp::views::zip(ops.dist_vec0, ops.dist_vec1);
+  auto dist = test_zip(ops.dist_vec0, ops.dist_vec1);
   static_assert(compliant_view<decltype(dist)>);
   EXPECT_TRUE(check_view(local, dist));
 }
@@ -76,104 +36,174 @@ TYPED_TEST(Zip, Dist2) {
 TYPED_TEST(Zip, Dist3) {
   Ops3<TypeParam> ops(10);
 
-  EXPECT_TRUE(
-      check_view(rng::views::zip(ops.vec0, ops.vec1, ops.vec2),
-                 xhp::views::zip(ops.dist_vec0, ops.dist_vec1, ops.dist_vec2)));
+  auto local = rng::views::zip(ops.vec0, ops.vec1, ops.vec2);
+  auto dist = test_zip(ops.dist_vec0, ops.dist_vec1, ops.dist_vec2);
+  static_assert(compliant_view<decltype(dist)>);
+  EXPECT_TRUE(check_view(local, dist));
 }
 
 TYPED_TEST(Zip, Dist3Distance) {
   Ops3<TypeParam> ops(10);
 
-  EXPECT_EQ(rng::distance(rng::views::zip(ops.vec0, ops.vec1, ops.vec2)),
-            rng::distance(
-                xhp::views::zip(ops.dist_vec0, ops.dist_vec1, ops.dist_vec2)));
+  EXPECT_EQ(
+      rng::distance(rng::views::zip(ops.vec0, ops.vec1, ops.vec2)),
+      rng::distance(test_zip(ops.dist_vec0, ops.dist_vec1, ops.dist_vec2)));
 }
 
-TYPED_TEST(Zip, CopyConstructor) {
-  Ops2<TypeParam> ops(10);
-
-  auto dist = xhp::views::zip(ops.dist_vec0, ops.dist_vec1);
-  auto dist_copy(dist);
-  EXPECT_EQ(dist, dist_copy);
-}
-
-TYPED_TEST(Zip, Iota) {
+TYPED_TEST(Zip, RangeSegments) {
   Ops1<TypeParam> ops(10);
 
-  auto local = rng::views::zip(xhp::views::iota(100), ops.vec);
-  auto dist = xhp::views::zip(xhp::views::iota(100), ops.dist_vec);
-  static_assert(compliant_view<decltype(dist)>);
-  EXPECT_TRUE(check_view(local, dist));
-}
-
-TYPED_TEST(Zip, Iota2nd) {
-  Ops1<TypeParam> ops(10);
-
-  EXPECT_TRUE(check_view(rng::views::zip(ops.vec, xhp::views::iota(100)),
-                         xhp::views::zip(ops.dist_vec, xhp::views::iota(100))));
+  auto local = rng::views::zip(ops.vec);
+  auto dist = test_zip(ops.dist_vec);
+  auto flat = rng::views::join(dr::ranges::segments(dist));
+  EXPECT_TRUE(is_equal(local, flat));
 }
 
 #if 0
-// doesn't compile in mhp
-TEST(Zip, ToTransform) {
-  Ops2<xhp::distributed_vector<int>> ops(10);
+// Will not compile with SHP
+TYPED_TEST(Zip, IterSegments) {
+  Ops1<TypeParam> ops(10);
 
-  auto mul = [](auto v) { return std::get<0>(v) * std::get<1>(v); };
-  auto local = rng::views::transform(rng::views::zip(ops.vec0, ops.vec1), mul);
-  auto dist =
-      xhp::views::transform(xhp::views::zip(ops.dist_vec0, ops.dist_vec1), mul);
-  static_assert(compliant_view<decltype(dist)>);
-  EXPECT_EQ(local, dist);
+  auto local = rng::views::zip(ops.vec);
+  auto dist = test_zip(ops.dist_vec);
+  auto flat = rng::views::join(dr::ranges::segments(dist.begin()));
+  EXPECT_TRUE(is_equal(local, flat));
 }
 #endif
 
-TYPED_TEST(Zip, All) {
-  Ops2<TypeParam> ops(10);
+TYPED_TEST(Zip, Drop) {
+  Ops1<TypeParam> ops(10);
 
-  EXPECT_TRUE(check_view(
-      rng::views::zip(rng::views::all(ops.vec0), rng::views::all(ops.vec1)),
-      xhp::views::zip(rng::views::all(ops.dist_vec0),
-                      rng::views::all(ops.dist_vec1))));
+  auto local = rng::views::drop(rng::views::zip(ops.vec), 2);
+  auto dist = xhp::views::drop(test_zip(ops.dist_vec), 2);
+
+  auto flat = rng::views::join(dr::ranges::segments(dist));
+  EXPECT_EQ(local, dist);
+  EXPECT_TRUE(is_equal(local, flat));
 }
 
-TYPED_TEST(Zip, L_Value) {
-  Ops2<TypeParam> ops(10);
+TYPED_TEST(Zip, ConsumingAll) {
+  Ops1<TypeParam> ops(10);
 
-  auto l_value = rng::views::all(ops.vec0);
-  auto d_l_value = rng::views::all(ops.dist_vec0);
-  EXPECT_TRUE(
-      check_view(rng::views::zip(l_value, rng::views::all(ops.vec1)),
-                 xhp::views::zip(d_l_value, rng::views::all(ops.dist_vec1))));
+  auto local = rng::views::zip(rng::views::all(ops.vec));
+  auto dist = test_zip(xhp::views::all(ops.dist_vec));
+  static_assert(compliant_view<decltype(dist)>);
+  EXPECT_EQ(local, dist);
 }
 
-TYPED_TEST(Zip, Subrange) {
-  Ops2<TypeParam> ops(10);
+TYPED_TEST(Zip, FeedingAll) {
+  Ops1<TypeParam> ops(10);
 
-  EXPECT_TRUE(check_view(
-      rng::views::zip(rng::subrange(ops.vec0.begin() + 1, ops.vec0.end() - 1),
-                      rng::subrange(ops.vec1.begin() + 1, ops.vec1.end() - 1)),
-      xhp::views::zip(
-          rng::subrange(ops.dist_vec0.begin() + 1, ops.dist_vec0.end() - 1),
-          rng::subrange(ops.dist_vec1.begin() + 1, ops.dist_vec1.end() - 1))));
+  auto local = rng::views::all(rng::views::zip(ops.vec));
+  auto dist = xhp::views::all(test_zip(ops.dist_vec));
+  static_assert(compliant_view<decltype(dist)>);
+  EXPECT_EQ(local, dist);
 }
 
 TYPED_TEST(Zip, ForEach) {
   Ops2<TypeParam> ops(10);
 
   auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };
-  xhp::for_each(xhp::views::zip(ops.dist_vec0, ops.dist_vec1), copy);
+  xhp::for_each(test_zip(ops.dist_vec0, ops.dist_vec1), copy);
   rng::for_each(rng::views::zip(ops.vec0, ops.vec1), copy);
 
   EXPECT_EQ(ops.vec0, ops.dist_vec0);
   EXPECT_EQ(ops.vec1, ops.dist_vec1);
 }
 
+TYPED_TEST(Zip, ForEachDrop) {
+  Ops2<TypeParam> ops(10);
+
+  auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };
+  xhp::for_each(xhp::views::drop(test_zip(ops.dist_vec0, ops.dist_vec1), 1),
+                copy);
+  rng::for_each(xhp::views::drop(rng::views::zip(ops.vec0, ops.vec1), 1), copy);
+
+  EXPECT_EQ(ops.vec0, ops.dist_vec0);
+  EXPECT_EQ(ops.vec1, ops.dist_vec1);
+}
+
+TYPED_TEST(Zip, ConsumingSubrange) {
+  Ops2<TypeParam> ops(10);
+
+  auto local =
+      rng::views::zip(rng::subrange(ops.vec0.begin() + 1, ops.vec0.end() - 1),
+                      rng::subrange(ops.vec1.begin() + 1, ops.vec1.end() - 1));
+  auto dist = test_zip(
+      rng::subrange(ops.dist_vec0.begin() + 1, ops.dist_vec0.end() - 1),
+      rng::subrange(ops.dist_vec1.begin() + 1, ops.dist_vec1.end() - 1));
+  EXPECT_EQ(local, dist);
+}
+
+TEST(Zip, FeedingTransform) {
+  Ops2<xhp::distributed_vector<int>> ops(10);
+
+  auto mul = [](auto v) { return std::get<0>(v) * std::get<1>(v); };
+  auto local = rng::views::transform(rng::views::zip(ops.vec0, ops.vec1), mul);
+  auto dist_zip = test_zip(ops.dist_vec0, ops.dist_vec1);
+  auto dist = xhp::views::transform(dist_zip, mul);
+  static_assert(compliant_view<decltype(dist)>);
+  EXPECT_EQ(local, dist);
+}
+
+TEST(Zip, CopyConstructor) {
+  Ops2<xhp::distributed_vector<int>> ops(10);
+
+  auto dist = test_zip(ops.dist_vec0, ops.dist_vec1);
+  auto dist_copy(dist);
+  EXPECT_EQ(dist, dist_copy);
+}
+
+TYPED_TEST(Zip, TransformReduce) {
+  Ops2<TypeParam> ops(10);
+
+  auto mul = [](auto v) { return std::get<0>(v) * std::get<1>(v); };
+
+  auto local = rng::views::transform(rng::views::zip(ops.vec0, ops.vec1), mul);
+  auto local_reduce = std::reduce(local.begin(), local.end());
+
+  auto dist =
+      xhp::views::transform(test_zip(ops.dist_vec0, ops.dist_vec1), mul);
+  auto dist_reduce = xhp::reduce(dist);
+
+  EXPECT_EQ(local_reduce, dist_reduce);
+}
+
+TYPED_TEST(Zip, IotaStaticAssert) {
+  Ops1<TypeParam> ops(10);
+
+  auto dist = test_zip(xhp::views::iota(100), ops.dist_vec);
+  static_assert(std::forward_iterator<decltype(dist.begin())>);
+  static_assert(std::forward_iterator<decltype(dist.end())>);
+  static_assert(std::forward_iterator<decltype(rng::begin(dist))>);
+  static_assert(std::forward_iterator<decltype(rng::end(dist))>);
+  using Dist = decltype(dist);
+  static_assert(rng::forward_range<Dist>);
+  static_assert(dr::distributed_range<Dist>);
+}
+
+TYPED_TEST(Zip, Iota) {
+  Ops1<TypeParam> ops(10);
+
+  auto local = rng::views::zip(rng::views::iota(100), ops.vec);
+  auto dist = test_zip(xhp::views::iota(100), ops.dist_vec);
+  static_assert(compliant_view<decltype(dist)>);
+  EXPECT_EQ(local, dist);
+}
+
+TYPED_TEST(Zip, Iota2nd) {
+  Ops1<TypeParam> ops(10);
+
+  EXPECT_TRUE(check_view(rng::views::zip(ops.vec, rng::views::iota(100)),
+                         test_zip(ops.dist_vec, xhp::views::iota(100))));
+}
+
 TYPED_TEST(Zip, ForEachIota) {
   Ops1<TypeParam> ops(10);
 
   auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };
-  xhp::for_each(xhp::views::zip(xhp::views::iota(100), ops.dist_vec), copy);
-  rng::for_each(rng::views::zip(xhp::views::iota(100), ops.vec), copy);
+  xhp::for_each(test_zip(xhp::views::iota(100), ops.dist_vec), copy);
+  rng::for_each(rng::views::zip(rng::views::iota(100), ops.vec), copy);
 
   EXPECT_EQ(ops.vec, ops.dist_vec);
   EXPECT_EQ(ops.vec, ops.dist_vec);

--- a/test/gtest/common/zip_local.cpp
+++ b/test/gtest/common/zip_local.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-tests.hpp"
+
+template <typename... Rs> auto test_zip(Rs &&...rs) {
+  return xhp::views::zip(std::forward<Rs>(rs)...);
+}
+
+// Fixture
+class ZipLocal : public ::testing::Test {
+protected:
+  void SetUp() override {
+    int val = 100;
+    for (std::size_t i = 0; i < ops.size(); i++) {
+      auto &op = ops[i];
+      auto &mop = mops[i];
+      op.resize(10);
+      mop.resize(10);
+      rng::iota(op, val);
+      rng::iota(mop, val);
+      val += 100;
+    }
+  }
+
+  std::array<std::vector<int>, 3> ops;
+  std::array<std::vector<int>, 3> mops;
+};
+
+// Try 1, 2, 3 to check pair/tuple issues
+TEST_F(ZipLocal, Op1) { EXPECT_EQ(rng::views::zip(ops[0]), test_zip(ops[0])); }
+
+TEST_F(ZipLocal, Op2) {
+  EXPECT_EQ(rng::views::zip(ops[0], ops[1]), test_zip(ops[0], ops[1]));
+}
+
+TEST_F(ZipLocal, Op3) {
+  EXPECT_EQ(rng::views::zip(ops[0], ops[1], ops[2]),
+            test_zip(ops[0], ops[1], ops[2]));
+}
+
+TEST_F(ZipLocal, Distance) {
+  EXPECT_EQ(rng::distance(rng::views::zip(ops[0], ops[1], ops[2])),
+            rng::distance(test_zip(ops[0], ops[1], ops[2])));
+}
+
+TEST_F(ZipLocal, Size) {
+  auto z = test_zip(ops[0], ops[1]);
+  EXPECT_EQ(rng::size(ops[0]), rng::size(z));
+}
+
+TEST_F(ZipLocal, Begin) {
+  auto z = test_zip(ops[0], ops[1]);
+  auto r = rng::views::zip(ops[0], ops[1]);
+  EXPECT_EQ(*r.begin(), *z.begin());
+}
+
+TEST_F(ZipLocal, End) {
+  auto z = test_zip(ops[0], ops[1]);
+  auto r = rng::views::zip(ops[0], ops[1]);
+  EXPECT_EQ(r.end() - r.begin(), z.end() - z.begin());
+}
+
+TEST_F(ZipLocal, CpoBeginEnd) {
+  auto z = test_zip(ops[0], ops[1]);
+  auto r = rng::views::zip(ops[0], ops[1]);
+  EXPECT_EQ(rng::end(r) - rng::begin(r), rng::end(z) - rng::begin(z));
+}
+
+TEST_F(ZipLocal, All) {
+  auto z = test_zip(rng::views::all(ops[0]));
+  auto r = rng::views::zip(rng::views::all(ops[0]));
+  EXPECT_EQ(r, z);
+}
+
+TEST_F(ZipLocal, Iota) {
+  auto z = test_zip(ops[0], xhp::views::iota(10));
+  auto r = rng::views::zip(ops[0], rng::views::iota(10));
+  EXPECT_EQ(r, z);
+}
+
+TEST_F(ZipLocal, IterPlusPlus) {
+  auto z = test_zip(ops[0], ops[1]);
+  auto r = rng::views::zip(ops[0], ops[1]);
+  auto z_iter = z.begin();
+  z_iter++;
+  auto r_iter = r.begin();
+  r_iter++;
+  EXPECT_EQ(*r_iter, *z_iter);
+}
+
+TEST_F(ZipLocal, IterEquals) {
+  auto z = test_zip(ops[0], ops[1]);
+  EXPECT_TRUE(z.begin() == z.begin());
+  EXPECT_FALSE(z.begin() == z.begin() + 1);
+}
+
+TEST_F(ZipLocal, For) {
+  auto z = test_zip(ops[0], ops[1]);
+
+  auto i = 0;
+  for (auto it = z.begin(); it != z.end(); it++) {
+    // values are same
+    EXPECT_EQ(this->ops[0][i], std::get<0>(*it));
+    EXPECT_EQ(this->ops[1][i], std::get<1>(*it));
+
+    // addresses are same
+    EXPECT_EQ(&(this->ops[0][i]), &std::get<0>(*it));
+    EXPECT_EQ(&(this->ops[1][i]), &std::get<1>(*it));
+    i++;
+  };
+  EXPECT_EQ(ops[0].size(), i);
+}
+
+TEST_F(ZipLocal, RangeFor) {
+  auto z = test_zip(ops[0], ops[1]);
+
+  auto i = 0;
+  for (auto v : z) {
+    // values are same
+    EXPECT_EQ(this->ops[0][i], std::get<0>(v));
+    EXPECT_EQ(this->ops[1][i], std::get<1>(v));
+
+    // addresses are same
+    EXPECT_EQ(&(this->ops[0][i]), &std::get<0>(v));
+    EXPECT_EQ(&(this->ops[1][i]), &std::get<1>(v));
+    i++;
+  };
+  EXPECT_EQ(ops[0].size(), i);
+}
+
+TEST_F(ZipLocal, ForEach) {
+  auto z = test_zip(ops[0], ops[1]);
+
+  auto i = 0;
+  auto check = [this, &i](auto v) {
+    // values are same
+    EXPECT_EQ(this->ops[0][i], std::get<0>(v));
+    EXPECT_EQ(this->ops[1][i], std::get<1>(v));
+
+    // addresses are same
+    EXPECT_EQ(&(this->ops[0][i]), &std::get<0>(v));
+    EXPECT_EQ(&(this->ops[1][i]), &std::get<1>(v));
+    i++;
+  };
+  rng::for_each(z, check);
+  EXPECT_EQ(ops[0].size(), i);
+}
+
+TEST_F(ZipLocal, Mutate) {
+  auto r = rng::views::zip(ops[0], ops[1]);
+  auto x = test_zip(mops[0], mops[1]);
+
+  std::get<0>(r[0]) = 99;
+  std::get<0>(x[0]) = 99;
+  EXPECT_EQ(ops[0], mops[0]);
+  EXPECT_EQ(ops[1], mops[1]);
+  static_assert(rng::random_access_range<decltype(x)>);
+}
+
+TEST_F(ZipLocal, MutateForEach) {
+  auto r = rng::views::zip(ops[0], ops[1]);
+  auto x = test_zip(mops[0], mops[1]);
+  auto n2 = [](auto &&v) {
+    std::get<0>(v) += 1;
+    std::get<1>(v) = -std::get<1>(v);
+  };
+
+  rng::for_each(r, n2);
+  rng::for_each(x, n2);
+  EXPECT_EQ(ops[0], mops[0]);
+  EXPECT_EQ(ops[1], mops[1]);
+
+  static_assert(rng::random_access_range<decltype(x)>);
+}

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -308,7 +308,7 @@ namespace DR_RANGES_NAMESPACE {
 
 template <rng::forward_range R1, rng::forward_range R2>
 bool operator==(R1 &&r1, R2 &&r2) {
-  return is_equal(r1, r2);
+  return is_equal(std::forward<R1>(r1), std::forward<R2>(r2));
 }
 
 template <typename... Ts>

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -21,10 +21,12 @@ add_executable(
   ../common/take.cpp
   ../common/transform_view.cpp
   ../common/zip.cpp
+  ../common/zip_local.cpp
   alignment.cpp
   distributed_vector.cpp
   reduce.cpp
   stencil.cpp
+  segmented.cpp
 )
 target_link_libraries(
   mhp-tests

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -50,6 +50,9 @@ target_link_libraries(
 )
 target_compile_definitions(quick-test PRIVATE QUICK_TEST)
 
+add_executable(mpi-test mpi-test.cpp)
+target_link_libraries(mpi-test MPI::MPI_CXX)
+
 cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)
 
 if (NOT MPI_IMPL STREQUAL "openmpi")

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -50,9 +50,6 @@ target_link_libraries(
 )
 target_compile_definitions(quick-test PRIVATE QUICK_TEST)
 
-add_executable(mpi-test mpi-test.cpp)
-target_link_libraries(mpi-test MPI::MPI_CXX)
-
 cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)
 
 if (NOT MPI_IMPL STREQUAL "openmpi")

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -35,6 +35,21 @@ target_link_libraries(
   DR::mpi
 )
 
+# skeleton for rapid builds of individual tests, feel free to change
+# this
+add_executable(
+  quick-test
+  mhp-tests.cpp
+  ../common/zip.cpp
+)
+target_link_libraries(
+  quick-test
+  GTest::gtest_main
+  cxxopts
+  DR::mpi
+)
+target_compile_definitions(quick-test PRIVATE QUICK_TEST)
+
 cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)
 
 if (NOT MPI_IMPL STREQUAL "openmpi")

--- a/test/gtest/mhp/segmented.cpp
+++ b/test/gtest/mhp/segmented.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-tests.hpp"
+
+#include <dr/mhp/views/segmented.hpp>
+
+// Fixture
+class Segmented : public ::testing::Test {
+protected:
+  void SetUp() override { dr::mhp::iota(dist_vec, 100); }
+
+  Segmented() : dist_vec(10) {}
+
+  dr::mhp::distributed_vector<int> dist_vec;
+};
+
+TEST_F(Segmented, StaticAssert) {
+  auto segmented = dr::mhp::segmented_view(rng::views::iota(100),
+                                           dr::ranges::segments(dist_vec));
+  static_assert(std::forward_iterator<decltype(segmented.begin())>);
+  static_assert(rng::forward_range<decltype(segmented)>);
+}
+
+TEST_F(Segmented, Basic) {
+  auto segmented = dr::mhp::segmented_view(rng::views::iota(100),
+                                           dr::ranges::segments(dist_vec));
+  EXPECT_EQ(dr::ranges::segments(dist_vec), segmented);
+}

--- a/test/gtest/mhp/xhp-tests.hpp
+++ b/test/gtest/mhp/xhp-tests.hpp
@@ -16,16 +16,16 @@ extern std::size_t comm_size;
 namespace xhp = dr::mhp;
 
 template <typename V>
-concept compliant_view =
-    rng::forward_range<V> && rng::random_access_range<V> &&
-    rng::viewable_range<V> && requires(V &v) {
-      // test one at a time so error is apparent
-      dr::ranges::segments(v);
-      dr::ranges::rank(dr::ranges::segments(v)[0]);
-      rng::begin(dr::ranges::segments(v)[0]);
-      dr::ranges::local(rng::begin(dr::ranges::segments(v)[0]));
-      dr::mhp::local_segments(v);
-    };
+concept compliant_view = rng::forward_range<V> && rng::random_access_range<V> &&
+                         rng::viewable_range<V> && requires(V &v) {
+                           // test one at a time so error is apparent
+                           dr::ranges::segments(v);
+                           dr::ranges::segments(v).begin();
+                           *dr::ranges::segments(v).begin();
+                           dr::ranges::rank(*dr::ranges::segments(v).begin());
+                           //  dr::ranges::local(rng::begin(dr::ranges::segments(v)[0]));
+                           //  dr::mhp::local_segments(v);
+                         };
 
 inline void barrier() { dr::mhp::barrier(); }
 inline void fence() { dr::mhp::fence(); }
@@ -42,3 +42,14 @@ using AllTypes = ::testing::Types<
 #else
 using AllTypes = CPUTypes;
 #endif
+
+namespace dr::mhp {
+
+template <typename DV>
+inline std::ostream &operator<<(std::ostream &os,
+                                const dv_segment<DV> &segment) {
+  os << fmt::format("{}", segment);
+  return os;
+}
+
+} // namespace dr::mhp

--- a/test/gtest/mhp/xhp-tests.hpp
+++ b/test/gtest/mhp/xhp-tests.hpp
@@ -32,6 +32,13 @@ inline void fence() { dr::mhp::fence(); }
 
 #include "common-tests.hpp"
 
+#ifdef QUICK_TEST
+
+// minimal testing for quick builds
+using AllTypes = ::testing::Types<dr::mhp::distributed_vector<int>>;
+
+#else
+
 using CPUTypes = ::testing::Types<dr::mhp::distributed_vector<int>,
                                   dr::mhp::distributed_vector<float>>;
 
@@ -41,6 +48,8 @@ using AllTypes = ::testing::Types<
     dr::mhp::distributed_vector<float, dr::mhp::sycl_shared_allocator<float>>>;
 #else
 using AllTypes = CPUTypes;
+#endif
+
 #endif
 
 namespace dr::mhp {

--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   ../common/take.cpp
   ../common/transform_view.cpp
   ../common/zip.cpp
+  ../common/zip_local.cpp
   containers.cpp
   algorithms.cpp
   copy.cpp


### PR DESCRIPTION
Only relies on `zip_view` and iterator having a base field.  It should be possible to implement the support for distributed with CPO's, but for now, local/segments/rank are MHP-specific methods. 

This implementation eliminates some of the issues with the earlier implementation. The views/iterators do not need to store std::vector. Instead, it implements the segments as a forward_range instead of a random_access_range. The iterator does not have pointers to the view.
