### PR TITLE
Add `tile()` to `mhp/dense_matrix`

### DIFF
--- a/examples/mhp/CMakeLists.txt
+++ b/examples/mhp/CMakeLists.txt
@@ -16,6 +16,13 @@ target_link_libraries(
   DR::mpi)
 add_mpi_test(stencil-1d stencil-1d 2)
 
+add_executable(tile-example tile-example.cpp)
+target_link_libraries(
+  tile-example
+  cxxopts
+  DR::mpi)
+add_mpi_test(tile-example tile-example 2)
+
 add_executable(stencil-1d-array stencil-1d-array.cpp)
 target_link_libraries(
   stencil-1d-array

--- a/examples/mhp/tile-example.cpp
+++ b/examples/mhp/tile-example.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <algorithm>
+
+#include "cxxopts.hpp"
+#include "mpi.h"
+
+#include "dr/mhp.hpp"
+
+using T = float;
+
+MPI_Comm comm;
+int comm_rank;
+int comm_size;
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  comm = MPI_COMM_WORLD;
+  MPI_Comm_rank(comm, &comm_rank);
+  MPI_Comm_size(comm, &comm_size);
+  dr::mhp::init();
+
+  std::size_t nc = 16;
+  std::size_t nr = 16;
+
+  {
+
+    dr::halo_bounds hb(1); // 1 row
+    dr::mhp::distributed_dense_matrix<T> a(nr, nc, -1, hb), b(nr, nc, -1, hb);
+
+    // different operation on every row - user must be aware of rows
+    // distribution
+    for (auto r = a.rows().begin(); r != a.rows().end(); r++) {
+      if (r.is_local())
+        rng::iota(*r, 10);
+    }
+
+    for (auto r = a.rows().begin(); r != a.rows().end(); r++) {
+      if (r.is_local()) {
+        auto &&row = *r;
+        fmt::print("{}\n", row);
+      }
+    }
+
+    dr::mhp::fence();
+    fflush(stdout);
+    MPI_Barrier(comm);
+    fflush(stdout);
+    MPI_Barrier(comm);
+
+    if (comm_rank == 0) {
+      for (std::size_t i = 0; i < a.grid_shape()[0]; i++) {
+        for (std::size_t j = 0; j < a.grid_shape()[1]; j++) {
+          fmt::print("Tile {}, {}\n", i, j);
+
+          auto &&tile = a.tile({i, j});
+
+          for (auto &&[index, value] : tile) {
+            auto &&[i, j] = index;
+            fmt::print("({}, {}): {}\n", i, j, value);
+          }
+        }
+      }
+    }
+
+    /*
+
+      dr::mhp::for_each(b.rows(), [](auto row) { rng::iota(row, 10); });
+
+      for (std::size_t i = 0; i < a.grid_shape()[0]; i++) {
+        for (std::size_t j = 0; j < a.grid_shape()[1]; j++) {
+          fmt::print("Tile {}, {}\n", i, j);
+
+          auto&& tile = a.tile({i, j});
+
+          for (auto&& [index, value] : tile) {
+            auto&& [i, j] = index;
+            fmt::print("({}, {}): {}\n", i, j, value);
+          }
+        }
+      }
+      */
+
+    MPI_Barrier(comm);
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/examples/mhp/tile-example.cpp
+++ b/examples/mhp/tile-example.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
   {
 
     dr::halo_bounds hb(1); // 1 row
-    dr::mhp::distributed_dense_matrix<T> a(nr, nc, -1, hb), b(nr, nc, -1, hb);
+    dr::mhp::distributed_dense_matrix<T> a(nr, nc, -1, hb);
 
     // different operation on every row - user must be aware of rows
     // distribution
@@ -51,6 +51,16 @@ int main(int argc, char *argv[]) {
     MPI_Barrier(comm);
 
     if (comm_rank == 0) {
+
+      fmt::print("Printing out whole matrix:\n");
+      for (auto &&tile : a.tile_segments()) {
+        for (auto &&[index, value] : tile) {
+          auto &&[i, j] = index;
+          fmt::print("({}, {}): {}\n", i, j, value);
+        }
+      }
+
+      fmt::print("Printing out individual tiles:\n");
       for (std::size_t i = 0; i < a.grid_shape()[0]; i++) {
         for (std::size_t j = 0; j < a.grid_shape()[1]; j++) {
           fmt::print("Tile {}, {}\n", i, j);
@@ -64,24 +74,6 @@ int main(int argc, char *argv[]) {
         }
       }
     }
-
-    /*
-
-      dr::mhp::for_each(b.rows(), [](auto row) { rng::iota(row, 10); });
-
-      for (std::size_t i = 0; i < a.grid_shape()[0]; i++) {
-        for (std::size_t j = 0; j < a.grid_shape()[1]; j++) {
-          fmt::print("Tile {}, {}\n", i, j);
-
-          auto&& tile = a.tile({i, j});
-
-          for (auto&& [index, value] : tile) {
-            auto&& [i, j] = index;
-            fmt::print("({}, {}): {}\n", i, j, value);
-          }
-        }
-      }
-      */
 
     MPI_Barrier(comm);
   }

--- a/include/dr/mhp/containers/distributed_dense_matrix.hpp
+++ b/include/dr/mhp/containers/distributed_dense_matrix.hpp
@@ -178,6 +178,29 @@ public:
 
   std::pair<int, int> local_rows_indices() { return local_rows_indices_; }
 
+  // Given a tile index, return a dense matrix view of that tile.
+  // dense_matrix_view is a view of a dense tile.
+  auto tile(key_type tile_index) {
+    assert(tile_index[0] == 0);
+
+    auto &&segment = segments()[tile_index[1]];
+
+    auto data = rng::begin(segment);
+
+    using Iter = decltype(data);
+
+    return dr::shp::dense_matrix_view<T, Iter>(
+        data,
+        key_type(std::min(segment_shape()[0],
+                          shape()[0] - segment_shape()[0] * tile_index[0]),
+                 segment_shape()[1]),
+        segment_shape()[1], dr::ranges::rank(segment));
+  }
+
+  key_type grid_shape() const noexcept {
+    return key_type(1, rng::size(segments_));
+  }
+
   // for debug only
 #if 1
   void dump_matrix(std::string msg) {


### PR DESCRIPTION
I want to suggest a few changes to the `distributed_dense_matrix` that @mateuszpn is working on.

For exposition purposes, assume we have a 8 x 8 matrix with a block row distribution between 4 ranks.  Each rank has a _tile_ of the matrix, which will be of size 2 x 8.  The tile grid, which is the grid of all the matrix tiles, will be of dimension 4 x 1.

```
Matrix A has shape {8, 8}

1 2 3 4 5 6 7 8
2 3 4 5 6 7 8 9
3 4 5 6 7 8 9 0
4 5 6 7 8 9 0 1
5 6 7 8 9 0 1 2
6 7 8 9 0 1 2 3
7 8 9 0 1 2 3 4
8 9 0 1 2 3 4 5

Rank 0's tile is at tile grid coordinates {0, 0}, and it has shape {2, 8}
1 2 3 4 5 6 7 8
2 3 4 5 6 7 8 9

Rank 1's tile is at tile grid coordinate {1, 0}
3 4 5 6 7 8 9 0
4 5 6 7 8 9 0 1

And so on, so that the tile grid has shape {4, 1}.
```

- `tile_shape()` returns the shape of the tiles of the matrix.  Here, `tile_shape()` will return `{2, 8}`.

- `grid_shape()` returns the shape of the tile grid.  Here, `grid_shape()` will return `{4, 1}`.

- `tile(index<> tile_index)` takes in an index in the tile grid and returns a view of that tile.  The resulting view is a `dense_matrix_view`, which provides a view of the tile.  (Also a remote range.)

```cpp
auto tile = a.tile({1, 0});

// `tile` is a `dense_matrix_view` with shape {2, 8}, holding the tile
// 3 4 5 6 7 8 9 0
// 4 5 6 7 8 9 0 1
```

I have cloned `mhp/dense_matrix` from Mateusz's personal fork to the `openapi-src` repo so that I can create this pull request.  (Unfortunately you cannot create a PR against a fork using a branch from the original repo.)