### PR TITLE
enable zip IterSegments test for MHP

### DIFF
--- a/test/gtest/common/zip.cpp
+++ b/test/gtest/common/zip.cpp
@@ -59,7 +59,7 @@ TYPED_TEST(Zip, RangeSegments) {
   EXPECT_TRUE(is_equal(local, flat));
 }
 
-#if 0
+#ifndef TEST_SHP
 // Will not compile with SHP
 TYPED_TEST(Zip, IterSegments) {
   Ops1<TypeParam> ops(10);

--- a/test/gtest/mhp/xhp-tests.hpp
+++ b/test/gtest/mhp/xhp-tests.hpp
@@ -9,6 +9,8 @@
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
+#define TEST_MHP
+
 extern MPI_Comm comm;
 extern std::size_t comm_rank;
 extern std::size_t comm_size;

--- a/test/gtest/shp/xhp-tests.hpp
+++ b/test/gtest/shp/xhp-tests.hpp
@@ -9,6 +9,8 @@
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
+#define TEST_SHP
+
 // To share tests with MHP
 const std::size_t comm_rank = 0;
 const std::size_t comm_size = 1;


### PR DESCRIPTION
@BenBrock: The last time I tried, this test would not compile with SHP

Leaving it in common zip tests, but enabling only for MHP