### PR TITLE
mhp default_allocator 

### DIFF
--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -167,7 +167,7 @@ private:
 }; // dv_segment
 
 /// distributed vector
-template <typename T, typename Allocator = std::allocator<T>>
+template <typename T, typename Allocator = dr::mhp::default_allocator<T>>
 class distributed_vector {
 
 public:

--- a/include/dr/mhp/global.hpp
+++ b/include/dr/mhp/global.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <dr/mhp/sycl_support.hpp>
+
 namespace dr::mhp {
 
 namespace __detail {
@@ -59,7 +61,7 @@ inline void init() {
 }
 
 #ifdef SYCL_LANGUAGE_VERSION
-inline auto sycl_queue() { return __detail::gcontext()->sycl_queue_; }
+inline sycl::queue sycl_queue() { return __detail::gcontext()->sycl_queue_; }
 inline auto dpl_policy() { return __detail::gcontext()->dpl_policy_; }
 
 inline void init(sycl::queue q) {
@@ -77,4 +79,43 @@ inline const auto &dpl_policy() {
   return std::execution::seq;
 }
 #endif
+
+template <typename T> class default_allocator {
+public:
+  default_allocator() {
+#ifdef SYCL_LANGUAGE_VERSION
+    if (mhp::use_sycl()) {
+      sycl_allocator_ = sycl_shared_allocator<T>(sycl_queue());
+    }
+#endif
+  }
+
+  T *allocate(std::size_t sz) {
+#ifdef SYCL_LANGUAGE_VERSION
+    if (mhp::use_sycl()) {
+      return sycl_allocator_.allocate(sz);
+    }
+#endif
+
+    return std_allocator_.allocate(sz);
+  }
+
+  void deallocate(T *ptr, std::size_t sz) {
+#ifdef SYCL_LANGUAGE_VERSION
+    if (mhp::use_sycl()) {
+      sycl_allocator_.deallocate(ptr, sz);
+      return;
+    }
+#endif
+
+    std_allocator_.deallocate(ptr, sz);
+  }
+
+private:
+#ifdef SYCL_LANGUAGE_VERSION
+  sycl_shared_allocator<T> sycl_allocator_;
+#endif
+  std::allocator<T> std_allocator_;
+};
+
 } // namespace dr::mhp

--- a/include/dr/mhp/sycl_support.hpp
+++ b/include/dr/mhp/sycl_support.hpp
@@ -2,9 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 namespace dr::mhp {
 
 #ifdef SYCL_LANGUAGE_VERSION
+
+sycl::queue sycl_queue();
+
 namespace _detail {
 
 template <typename T, std::size_t Alignment>


### PR DESCRIPTION
MHP `default_allocator` uses global context to choose sycl or system memory. This should make it possible to decide at runtime whether to target sycl or cpu. Avoids compile-time penalty for expanding multiple templates when only difference is type of memory used.