### PR TITLE
do not error on unknown pragma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_compile_options(-Wno-tautological-constant-compare)
     # DPL turns on -fopenmp-simd, triggering optimization warnings in parallel stl
     add_compile_options(-Wno-error=pass-failed)
+    add_compile_options(-Wno-error=unknown-pragmas)
   endif()
 
   if(ENABLE_SYCL)


### PR DESCRIPTION
mhp ortce build hits this warning. Not sure why. Emit warning, but do not error.