### PR TITLE
drop testing of float vectors

### DIFF
--- a/test/gtest/mhp/xhp-tests.hpp
+++ b/test/gtest/mhp/xhp-tests.hpp
@@ -34,17 +34,8 @@ inline void fence() { dr::mhp::fence(); }
 
 #include "common-tests.hpp"
 
-#ifdef QUICK_TEST
-
 // minimal testing for quick builds
 using AllTypes = ::testing::Types<dr::mhp::distributed_vector<int>>;
-
-#else
-
-using AllTypes = ::testing::Types<dr::mhp::distributed_vector<int>,
-                                  dr::mhp::distributed_vector<float>>;
-
-#endif
 
 namespace dr::mhp {
 

--- a/test/gtest/shp/xhp-tests.hpp
+++ b/test/gtest/shp/xhp-tests.hpp
@@ -31,5 +31,4 @@ concept compliant_view = rng::forward_range<V> && requires(V &v) {
 
 #include "common-tests.hpp"
 
-using AllTypes = ::testing::Types<xhp::distributed_vector<int>,
-                                  xhp::distributed_vector<float>>;
+using AllTypes = ::testing::Types<xhp::distributed_vector<int>>;


### PR DESCRIPTION
CI takes 30 minutes, drop testing of float vectors and only test int to see if that will speed it up.