### PR TITLE
mpi 3 processes only test

### DIFF
--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -29,28 +29,38 @@ add_executable(
   reduce.cpp
   stencil.cpp
   segmented.cpp
+  slide_view.cpp
 )
-target_link_libraries(
-  mhp-tests
-  GTest::gtest_main
-  cxxopts
-  DR::mpi
+
+add_executable(
+  mhp-tests-3
+  mhp-tests.cpp
+  slide_view-3.cpp
 )
+
+foreach(test-exec IN ITEMS mhp-tests mhp-tests-3)
+  target_link_libraries(
+    ${test-exec}
+    GTest::gtest_main
+    cxxopts
+    DR::mpi
+  )
+endforeach()
 
 # skeleton for rapid builds of individual tests, feel free to change
 # this
-add_executable(
-  mhp-quick-test
-  mhp-tests.cpp
-  ../common/take.cpp
-)
-target_link_libraries(
-  mhp-quick-test
-  GTest::gtest_main
-  cxxopts
-  DR::mpi
-)
-target_compile_definitions(mhp-quick-test PRIVATE QUICK_TEST)
+#add_executable(
+#  mhp-quick-test
+#  mhp-tests.cpp
+#  ../common/take.cpp
+#)
+#target_link_libraries(
+#  mhp-quick-test
+#  GTest::gtest_main
+#  cxxopts
+#  DR::mpi
+#)
+#target_compile_definitions(mhp-quick-test PRIVATE QUICK_TEST)
 
 if (ENABLE_SYCL)
   target_compile_options(mhp-tests PRIVATE -fsycl)
@@ -66,6 +76,7 @@ endif()
 add_mpi_test(mhp-tests-2 mhp-tests 2)
 add_mpi_test(mhp-tests-3 mhp-tests 3)
 add_mpi_test(mhp-tests-4 mhp-tests 4)
+add_mpi_test(mhp-tests-3-only mhp-tests-3 3)
 
 if (ENABLE_SYCL)
   if (NOT MPI_IMPL STREQUAL "openmpi")

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -29,7 +29,6 @@ add_executable(
   reduce.cpp
   stencil.cpp
   segmented.cpp
-  slide_view.cpp
 )
 
 add_executable(

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -47,7 +47,9 @@ foreach(test-exec IN ITEMS mhp-tests mhp-tests-3)
 endforeach()
 
 # skeleton for rapid builds of individual tests, feel free to change
-# this
+# this, ucomment when developing but not commit to repo once you do PR
+
+# BEGIN OF SKELETON
 #add_executable(
 #  mhp-quick-test
 #  mhp-tests.cpp
@@ -60,10 +62,13 @@ endforeach()
 #  DR::mpi
 #)
 #target_compile_definitions(mhp-quick-test PRIVATE QUICK_TEST)
+#if (ENABLE_SYCL)
+#  target_compile_options(mhp-quick-test PRIVATE -fsycl)
+#endif()
+# END OF SKELETON
 
 if (ENABLE_SYCL)
   target_compile_options(mhp-tests PRIVATE -fsycl)
-  target_compile_options(mhp-quick-test PRIVATE -fsycl)
 endif()
 
 cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)

--- a/test/gtest/mhp/slide_view-3.cpp
+++ b/test/gtest/mhp/slide_view-3.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+// this test is going to be updated with PR with sliding-view
+// however it is commited as empty one in advance because another PR needs to
+// create its own MPI 3proc only tests and some exaple was needed
+
+#include "xhp-tests.hpp"
+
+template <typename T> class Slide3 : public testing::Test {};
+
+TYPED_TEST_SUITE(Slide3, AllTypes);
+
+TYPED_TEST(Slide3, suite_works_for_3_processes_only) {
+  EXPECT_EQ(dr::mhp::default_comm().size(), 3); // dr-style ignore
+}
+
+// more Slide3 tests are comming, all assume that there are 3 mpi processes


### PR DESCRIPTION
It is easier to write simple tests when one can assume there are only a fixed number of processes.
I'm creating a template for such a test. It is already going to be used in sliding-view and in dense-matrix.