### PR TITLE
add gbench + some microbenchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,17 +77,11 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
 
-  # For need this argument for google bench. Later, we want to turn on
-  # -Wall and need to repeat -Wno-tautol...  The SHELL: hack disables
-  # deduplication of options, allowing us to specify it twice.
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-    # Most code get warnings with -ffast-math
-    add_compile_options("SHELL: -Wno-tautological-constant-compare")
-  endif()
-
   #
   # Google test
   #
+  set(BENCHMARK_ENABLE_TESTING off)
+  set(BENCHMARK_ENABLE_WERROR off)
   FetchContent_Declare(
     googlebench
     GIT_REPOSITORY https://github.com/google/benchmark.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,26 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
 
+  # repeated later after we turn on Wall, but also needed for google bench
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    # Most code get warnings with -ffast-math
+    add_compile_options(-Wno-tautological-constant-compare)
+  endif()
+
+  #
+  # Google test
+  #
+  FetchContent_Declare(
+    googlebench
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.8.0
+  )
+  FetchContent_MakeAvailable(googlebench)
+
+
+  #
+  # Command-line options parser
+  #
   FetchContent_Declare(
     cxxopts
     GIT_REPOSITORY https://github.com/jarro2783/cxxopts.git
@@ -148,6 +168,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   add_subdirectory(test/gtest/serial)
   add_subdirectory(examples/mhp)
   add_subdirectory(test/gtest/mhp)
+  add_subdirectory(benchmarks/gbench/mhp)
 
   # Requires clang, icpx/llvm nightly do not support the tools
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ENABLE_SYCL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,12 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
 
-  # repeated later after we turn on Wall, but also needed for google bench
+  # For need this argument for google bench. Later, we want to turn on
+  # -Wall and need to repeat -Wno-tautol...  The SHELL: hack disables
+  # deduplication of options, allowing us to specify it twice.
   if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
     # Most code get warnings with -ffast-math
-    add_compile_options(-Wno-tautological-constant-compare)
+    add_compile_options("SHELL: -Wno-tautological-constant-compare")
   endif()
 
   #

--- a/benchmarks/gbench/common/distributed_vector.cpp
+++ b/benchmarks/gbench/common/distributed_vector.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-bench.hpp"
+
+using T = double;
+
+// Store result here to avoid compiler optimization of unused
+// operations
+T bit_bucket = 0;
+
+static void Fill_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> vec(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::fill(vec, 0);
+    }
+  }
+}
+
+BENCHMARK(Fill_DR);
+
+static void Fill_Local(benchmark::State &state) {
+  std::vector<T> vec(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      rng::fill(vec, 0);
+    }
+  }
+}
+
+BENCHMARK(Fill_Local);
+
+static void Copy_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> src(default_vector_size);
+  xhp::distributed_vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::copy(src, dst.begin());
+    }
+  }
+}
+
+BENCHMARK(Copy_DR);
+
+static void Copy_Local(benchmark::State &state) {
+  std::vector<T> src(default_vector_size);
+  std::vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      rng::copy(src, dst.begin());
+    }
+  }
+}
+
+BENCHMARK(Copy_Local);
+
+static void Reduce_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> src(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      bit_bucket += xhp::reduce(src);
+    }
+  }
+}
+
+BENCHMARK(Reduce_DR);
+
+static void Reduce_Local(benchmark::State &state) {
+  std::vector<T> src(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      bit_bucket +=
+          std::reduce(std::execution::par_unseq, src.begin(), src.end());
+    }
+  }
+}
+
+BENCHMARK(Reduce_Local);
+
+static void TransformIdentity_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> src(default_vector_size);
+  xhp::distributed_vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::transform(src, dst.begin(), std::identity());
+    }
+  }
+}
+
+BENCHMARK(TransformIdentity_DR);
+
+static void TransformIdentity_Local(benchmark::State &state) {
+  std::vector<T> src(default_vector_size);
+  std::vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      rng::transform(src, dst.begin(), std::identity());
+    }
+  }
+}
+
+BENCHMARK(TransformIdentity_Local);
+
+static void Mul_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> a(default_vector_size);
+  xhp::distributed_vector<T> b(default_vector_size);
+  xhp::distributed_vector<T> c(default_vector_size);
+  auto mul = [](auto v) {
+    auto [a, b] = v;
+    return a * b;
+  };
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::transform(xhp::views::zip(a, b), c.begin(), mul);
+    }
+  }
+}
+
+BENCHMARK(Mul_DR);
+
+static void Mul_Local(benchmark::State &state) {
+  std::vector<T> a(default_vector_size);
+  std::vector<T> b(default_vector_size);
+  std::vector<T> c(default_vector_size);
+  auto mul = [](auto a, auto b) { return a * b; };
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      std::transform(std::execution::par_unseq, a.begin(), a.end(), b.begin(),
+                     c.begin(), mul);
+    }
+  }
+}
+
+BENCHMARK(Mul_Local);
+
+static void DotProduct_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> a(default_vector_size);
+  xhp::distributed_vector<T> b(default_vector_size);
+  auto mul = [](auto v) {
+    auto [a, b] = v;
+    return a * b;
+  };
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      bit_bucket +=
+          xhp::reduce(xhp::views::zip(a, b) | xhp::views::transform(mul));
+    }
+  }
+}
+
+BENCHMARK(DotProduct_DR);
+
+static void DotProduct_Local(benchmark::State &state) {
+  std::vector<T> a(default_vector_size);
+  std::vector<T> b(default_vector_size);
+  auto mul = [](auto v) {
+    auto [a, b] = v;
+    return a * b;
+  };
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      auto &&m = rng::views::zip(a, b) | rng::views::transform(mul);
+      bit_bucket += std::reduce(std::execution::par_unseq, m.begin(), m.end());
+    }
+  }
+}
+
+BENCHMARK(DotProduct_Local);

--- a/benchmarks/gbench/common/distributed_vector.cpp
+++ b/benchmarks/gbench/common/distributed_vector.cpp
@@ -4,10 +4,12 @@
 
 #include "xhp-bench.hpp"
 
+#ifdef SYCL_LANGUAGE_VERSION
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/async>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
+#endif
 
 using T = double;
 

--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   mhp-bench
   mhp-bench.cpp
   ../common/distributed_vector.cpp
+  rooted.cpp
 )
 target_link_libraries(
   mhp-bench

--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+add_executable(
+  mhp-bench
+  mhp-bench.cpp
+  ../common/distributed_vector.cpp
+)
+target_link_libraries(
+  mhp-bench
+  benchmark::benchmark
+  cxxopts
+  DR::mpi
+)
+
+if (ENABLE_SYCL)
+  target_compile_options(mhp-bench PRIVATE -fsycl)
+endif()
+
+cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)
+
+if (NOT MPI_IMPL STREQUAL "openmpi")
+  # MPI_Win_create fails for communicator with size 1
+  add_mpi_test(mhp-bench-1 mhp-bench 1)
+endif()

--- a/benchmarks/gbench/mhp/mhp-bench.cpp
+++ b/benchmarks/gbench/mhp/mhp-bench.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "cxxopts.hpp"
+#include "dr/mhp.hpp"
+#include "mpi.h"
+#include <benchmark/benchmark.h>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+MPI_Comm comm;
+std::size_t comm_rank;
+std::size_t comm_size;
+
+std::size_t default_vector_size;
+std::size_t default_repetitions;
+
+cxxopts::ParseResult options;
+
+// This reporter does nothing.
+// We can use it to disable output from all but the root process
+class NullReporter : public ::benchmark::BenchmarkReporter {
+public:
+  NullReporter() {}
+  virtual bool ReportContext(const Context &) { return true; }
+  virtual void ReportRuns(const std::vector<Run> &) {}
+  virtual void Finalize() {}
+};
+
+void dr_init() {
+  if (options.count("sycl")) {
+#ifdef SYCL_LANGUAGE_VERSION
+    sycl::queue q;
+    if (comm_rank == 0) {
+      fmt::print("  run on sycl device: {}\n",
+                 q.get_device().get_info<sycl::info::device::name>());
+    }
+    dr::mhp::init(q);
+    return;
+#endif
+    assert(false && "sycl requested, but did not build with SYCL enabled");
+  }
+
+  if (comm_rank == 0) {
+    fmt::print("  run on CPU\n");
+  }
+  dr::mhp::init();
+}
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  comm = MPI_COMM_WORLD;
+  int rank, size;
+  MPI_Comm_rank(comm, &rank);
+  MPI_Comm_size(comm, &size);
+  comm_rank = rank;
+  comm_size = size;
+
+  benchmark::Initialize(&argc, argv);
+
+  cxxopts::Options options_spec(argv[0], "DR MHP tests");
+
+  // clang-format off
+  options_spec.add_options()
+    ("drhelp", "Print help")
+    ("log", "Enable logging")
+    ("sycl", "Execute on SYCL device")
+    ("reps", "Debug repetitions for short duration vector operations", cxxopts::value<std::size_t>()->default_value("1"))
+    ("vector-size", "Default vector size", cxxopts::value<std::size_t>()->default_value("100000000"))
+    ;
+  // clang-format on
+
+  try {
+    options = options_spec.parse(argc, argv);
+  } catch (const cxxopts::OptionParseException &e) {
+    std::cout << options_spec.help() << "\n";
+    exit(1);
+  }
+
+  if (options.count("drhelp")) {
+    std::cout << options_spec.help() << "\n";
+    exit(0);
+  }
+
+  std::ofstream *logfile = nullptr;
+  if (options.count("log")) {
+    logfile = new std::ofstream(fmt::format("dr.{}.log", comm_rank));
+    dr::drlog.set_file(*logfile);
+  }
+  dr::drlog.debug("Rank: {}\n", comm_rank);
+
+  default_vector_size = options["vector-size"].as<std::size_t>();
+  default_repetitions = options["reps"].as<std::size_t>();
+  fmt::print("Configuration:\n"
+             "  default vector size: {}\n"
+             "  default repetitions: {}\n",
+             default_vector_size, default_repetitions);
+
+  dr_init();
+  if (rank == 0) {
+    benchmark::RunSpecifiedBenchmarks();
+  } else {
+    NullReporter null_reporter;
+    benchmark::RunSpecifiedBenchmarks(&null_reporter);
+  }
+  // benchmark::Shutdown();
+
+  if (logfile) {
+    delete logfile;
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/benchmarks/gbench/mhp/mhp-bench.cpp
+++ b/benchmarks/gbench/mhp/mhp-bench.cpp
@@ -92,10 +92,12 @@ int main(int argc, char *argv[]) {
 
   default_vector_size = options["vector-size"].as<std::size_t>();
   default_repetitions = options["reps"].as<std::size_t>();
-  fmt::print("Configuration:\n"
-             "  default vector size: {}\n"
-             "  default repetitions: {}\n",
-             default_vector_size, default_repetitions);
+  if (comm_rank == 0) {
+    fmt::print("Configuration:\n"
+               "  default vector size: {}\n"
+               "  default repetitions: {}\n",
+               default_vector_size, default_repetitions);
+  }
 
   dr_init();
   if (rank == 0) {

--- a/benchmarks/gbench/mhp/rooted.cpp
+++ b/benchmarks/gbench/mhp/rooted.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-bench.hpp"
+
+using T = double;
+
+static void CopyDist2Local_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> src(default_vector_size);
+  std::vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::copy(0, src, dst.begin());
+    }
+  }
+}
+
+BENCHMARK(CopyDist2Local_DR);
+
+static void CopyLocal2Dist_DR(benchmark::State &state) {
+  std::vector<T> src(default_vector_size);
+  xhp::distributed_vector<T> dst(default_vector_size);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      xhp::copy(0, src, dst.begin());
+    }
+  }
+}
+
+BENCHMARK(CopyLocal2Dist_DR);

--- a/benchmarks/gbench/mhp/xhp-bench.hpp
+++ b/benchmarks/gbench/mhp/xhp-bench.hpp
@@ -13,3 +13,5 @@ namespace xhp = dr::mhp;
 
 extern std::size_t default_vector_size;
 extern std::size_t default_repetitions;
+
+#define BENCH_MHP

--- a/benchmarks/gbench/mhp/xhp-bench.hpp
+++ b/benchmarks/gbench/mhp/xhp-bench.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include "cxxopts.hpp"
+#include "dr/mhp.hpp"
+#include <benchmark/benchmark.h>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+namespace xhp = dr::mhp;
+
+extern std::size_t default_vector_size;
+extern std::size_t default_repetitions;


### PR DESCRIPTION
Added google benchmarks and implemented some micro benchmarks. DR is for distributed ranges and Local uses `std::/ranges::`
```
rscohn1@anpfclxlin02:mhp$ mpirun -n 1 ./mhp-bench --benchmark_time_unit=ms --reps 2
Configuration:
  default vector size: 100000000
  default repetitions: 2
  run on CPU
2023-05-19T11:40:13-05:00
Running ./mhp-bench
Run on (96 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 0.04, 0.16, 0.10
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
Fill_DR                        418 ms          418 ms            2
Fill_Local                     286 ms          286 ms            3
Copy_DR                        709 ms          708 ms            1
Copy_Local                     358 ms          358 ms            2
Reduce_DR                     32.1 ms         32.1 ms           16
Reduce_Local                   154 ms          153 ms            4
TransformIdentity_DR           686 ms          686 ms            1
TransformIdentity_Local        329 ms          329 ms            2
Mul_DR                         594 ms          593 ms            1
Mul_Local                      397 ms          397 ms            2
DotProduct_DR                 59.1 ms         59.1 ms           10
DotProduct_Local               271 ms          271 ms            2
rscohn1@anpfclxlin02:mhp$ mpirun -n 2 ./mhp-bench --benchmark_time_unit=ms --reps 2
Configuration:
  default vector size: 100000000
  default repetitions: 2
  run on CPU
Configuration:
  default vector size: 100000000
  default repetitions: 2
2023-05-19T11:40:40-05:00
Running ./mhp-bench
Run on (96 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 0.29, 0.21, 0.11
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
Fill_DR                        194 ms          194 ms            3
Fill_Local                     274 ms          274 ms            3
Copy_DR                        216 ms          216 ms            3
Copy_Local                     389 ms          389 ms            2
Reduce_DR                     19.9 ms         19.9 ms           30
Reduce_Local                   145 ms          145 ms            5
TransformIdentity_DR           194 ms          194 ms            3
TransformIdentity_Local        356 ms          356 ms            2
Mul_DR                         141 ms          141 ms            4
Mul_Local                      364 ms          364 ms            2
DotProduct_DR                 62.0 ms         62.0 ms           10
DotProduct_Local               262 ms          262 ms            3
```