### PR TITLE
more dot product microbenchmarks

### DIFF
--- a/benchmarks/gbench/common/dot_product.cpp
+++ b/benchmarks/gbench/common/dot_product.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-bench.hpp"
+
+#ifdef SYCL_LANGUAGE_VERSION
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/async>
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/numeric>
+#endif
+
+using T = double;
+
+T init_val = 1;
+
+void check_dp(auto actual, const nostd::source_location location =
+                               nostd::source_location::current()) {
+  auto expected = default_vector_size * init_val * init_val;
+  if (expected != actual) {
+    fmt::print("Error in {}\n"
+               "  Expected: {}\n"
+               "  Actual: {}\n",
+               location.function_name(), expected, actual);
+    exit(1);
+  } else {
+    return;
+  }
+}
+
+static void DotProduct_ZipReduce_DR(benchmark::State &state) {
+  xhp::distributed_vector<T> a(default_vector_size, init_val);
+  xhp::distributed_vector<T> b(default_vector_size, init_val);
+  auto mul = [](auto v) {
+    auto [a, b] = v;
+    return a * b;
+  };
+  T res;
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      res = xhp::reduce(xhp::views::zip(a, b) | xhp::views::transform(mul));
+      benchmark::DoNotOptimize(res);
+    }
+  }
+  check_dp(res);
+}
+
+BENCHMARK(DotProduct_ZipReduce_DR);
+
+static void DotProduct_ZipReduce_Std(benchmark::State &state) {
+  std::vector<T> a(default_vector_size, init_val);
+  std::vector<T> b(default_vector_size, init_val);
+  auto mul = [](auto v) {
+    auto [a, b] = v;
+    return a * b;
+  };
+  auto &&m = rng::views::zip(a, b) | rng::views::transform(mul);
+
+  T res;
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      res = std::reduce(std::execution::par_unseq, m.begin(), m.end());
+      benchmark::DoNotOptimize(res);
+    }
+  }
+  check_dp(res);
+}
+
+BENCHMARK(DotProduct_ZipReduce_Std);
+
+static void DotProduct_TransformReduce_Std(benchmark::State &state) {
+  std::vector<T> a(default_vector_size, init_val);
+  std::vector<T> b(default_vector_size, init_val);
+  auto mul = [](auto a, auto b) { return a * b; };
+
+  T res;
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      res = std::transform_reduce(std::execution::par_unseq, a.begin(), a.end(),
+                                  b.begin(), T(0), std::plus(), mul);
+      benchmark::DoNotOptimize(res);
+    }
+  }
+  check_dp(res);
+}
+
+BENCHMARK(DotProduct_TransformReduce_Std);
+
+static void DotProduct_Loop_Std(benchmark::State &state) {
+  std::vector<T> a(default_vector_size, init_val);
+  std::vector<T> b(default_vector_size, init_val);
+  T res;
+
+  for (auto _ : state) {
+    res = 0;
+    for (std::size_t i = 0; i < default_vector_size; i++) {
+      res += a[i] * b[i];
+    }
+    benchmark::DoNotOptimize(res);
+  }
+  check_dp(res);
+}
+
+BENCHMARK(DotProduct_Loop_Std);
+
+#ifdef SYCL_LANGUAGE_VERSION
+static void DotProduct_TransformReduce_DPL(benchmark::State &state) {
+  T res;
+  sycl::queue q;
+  auto policy = oneapi::dpl::execution::make_device_policy(q);
+
+  auto mul = [](auto a, auto b) { return a * b; };
+  auto a = sycl::malloc_device<T>(default_vector_size, q);
+  ;
+  auto b = sycl::malloc_device<T>(default_vector_size, q);
+  ;
+  q.fill(a, init_val, default_vector_size);
+  q.fill(b, init_val, default_vector_size);
+  q.wait();
+
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      res = std::transform_reduce(policy, a, a + default_vector_size, b, T(0),
+                                  std::plus(), mul);
+      benchmark::DoNotOptimize(res);
+    }
+  }
+  check_dp(res);
+}
+
+BENCHMARK(DotProduct_TransformReduce_DPL);
+#endif

--- a/benchmarks/gbench/common/dot_product.cpp
+++ b/benchmarks/gbench/common/dot_product.cpp
@@ -36,7 +36,7 @@ static void DotProduct_ZipReduce_DR(benchmark::State &state) {
     auto [a, b] = v;
     return a * b;
   };
-  T res;
+  T res = 0;
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       res = xhp::reduce(xhp::views::zip(a, b) | xhp::views::transform(mul));
@@ -57,7 +57,7 @@ static void DotProduct_ZipReduce_Std(benchmark::State &state) {
   };
   auto &&m = rng::views::zip(a, b) | rng::views::transform(mul);
 
-  T res;
+  T res = 0;
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       res = std::reduce(std::execution::par_unseq, m.begin(), m.end());
@@ -74,7 +74,7 @@ static void DotProduct_TransformReduce_Std(benchmark::State &state) {
   std::vector<T> b(default_vector_size, init_val);
   auto mul = [](auto a, auto b) { return a * b; };
 
-  T res;
+  T res = 0;
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       res = std::transform_reduce(std::execution::par_unseq, a.begin(), a.end(),
@@ -90,7 +90,7 @@ BENCHMARK(DotProduct_TransformReduce_Std);
 static void DotProduct_Loop_Std(benchmark::State &state) {
   std::vector<T> a(default_vector_size, init_val);
   std::vector<T> b(default_vector_size, init_val);
-  T res;
+  T res = 0;
 
   for (auto _ : state) {
     res = 0;
@@ -106,7 +106,7 @@ BENCHMARK(DotProduct_Loop_Std);
 
 #ifdef SYCL_LANGUAGE_VERSION
 static void DotProduct_TransformReduce_DPL(benchmark::State &state) {
-  T res;
+  T res = 0;
   sycl::queue q;
   auto policy = oneapi::dpl::execution::make_device_policy(q);
 

--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   mhp-bench
   mhp-bench.cpp
   ../common/distributed_vector.cpp
+  ../common/dot_product.cpp
   rooted.cpp
   mpi.cpp
 )

--- a/benchmarks/gbench/mhp/xhp-bench.hpp
+++ b/benchmarks/gbench/mhp/xhp-bench.hpp
@@ -4,10 +4,12 @@
 #pragma once
 
 #include "cxxopts.hpp"
-#include "dr/mhp.hpp"
 #include <benchmark/benchmark.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <vendor/source_location/source_location.hpp>
+
+#include "dr/mhp.hpp"
 
 namespace xhp = dr::mhp;
 

--- a/benchmarks/gbench/shp/CMakeLists.txt
+++ b/benchmarks/gbench/shp/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   shp-bench
   shp-bench.cpp
   ../common/distributed_vector.cpp
+  ../common/dot_product.cpp
 )
 target_link_libraries(
   shp-bench

--- a/benchmarks/gbench/shp/xhp-bench.hpp
+++ b/benchmarks/gbench/shp/xhp-bench.hpp
@@ -4,10 +4,12 @@
 #pragma once
 
 #include "cxxopts.hpp"
-#include "dr/shp.hpp"
 #include <benchmark/benchmark.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <vendor/source_location/source_location.hpp>
+
+#include "dr/shp.hpp"
 
 namespace xhp = dr::shp;
 


### PR DESCRIPTION
More microbenchmarks for dot product. Some measurements on a CPU-only system. MHP SYCL version has poor performance 😦. 

SHP outperforms DPL 🏆 

MHP

```
rscohn1@anpfclxlin02:mhp$ ../mhp/mhp-bench --benchmark_filter=DotProduct* --benchmark_time_unit=ms
Configuration:
  default vector size: 100000000
  default repetitions: 1
  run on CPU
2023-05-21T07:51:16-05:00
Running ../mhp/mhp-bench
Run on (96 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 0.67, 1.87, 1.34
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
DotProduct_ZipReduce_DR               176 ms          176 ms            5
DotProduct_ZipReduce_Std              157 ms          157 ms            5
DotProduct_TransformReduce_Std        155 ms          155 ms            5
DotProduct_Loop_Std                   141 ms          141 ms            5
DotProduct_TransformReduce_DPL       31.9 ms         28.1 ms           25
rscohn1@anpfclxlin02:mhp$ ../mhp/mhp-bench --benchmark_filter=DotProduct* --benchmark_time_unit=ms --sycl
Configuration:
  default vector size: 100000000
  default repetitions: 1
  run on sycl device: Intel(R) Xeon(R) Platinum 8260M CPU @ 2.40GHz
2023-05-21T07:51:33-05:00
Running ../mhp/mhp-bench
Run on (96 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 7.71, 3.27, 1.80
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
DotProduct_ZipReduce_DR              1286 ms         1253 ms            1
DotProduct_ZipReduce_Std              135 ms          135 ms            5
DotProduct_TransformReduce_Std        172 ms          172 ms            3
DotProduct_Loop_Std                   156 ms          156 ms            5
DotProduct_TransformReduce_DPL       30.9 ms         27.2 ms           25
rscohn1@anpfclxlin02:mhp$
```

SHP

```
rscohn1@anpfclxlin02:mhp$ ../shp/shp-bench --benchmark_filter=DotProduct* --benchmark_time_unit=ms
Configuration:
  default vector size: 100000000
  default repetitions: 1
  number of devices requested: 0
    Intel(R) Xeon(R) Platinum 8260M CPU @ 2.40GHz
    Intel(R) Xeon(R) Platinum 8260M CPU @ 2.40GHz
2023-05-21T07:53:50-05:00
Running ../shp/shp-bench
Run on (96 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 1.71, 3.11, 2.00
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations
-------------------------------------------------------------------------
DotProduct_ZipReduce_DR              26.2 ms         17.8 ms           39
DotProduct_ZipReduce_Std              143 ms          143 ms            4
DotProduct_TransformReduce_Std        143 ms          143 ms            4
DotProduct_Loop_Std                   135 ms          135 ms            5
DotProduct_TransformReduce_DPL       32.2 ms         27.7 ms           27
rscohn1@anpfclxlin02:mhp$
```