### PR TITLE
update oneDPL to official version which fixed unused variable warning

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,8 +4,8 @@
 
 FetchContent_Declare(
   dpl
-  GIT_REPOSITORY https://github.com/rscohn2/oneDPL.git
-  GIT_TAG patch-1
+  GIT_REPOSITORY https://github.com/oneapi-src/oneDPL.git
+  GIT_TAG oneDPL-2022.1.0-rc3
   )
 FetchContent_MakeAvailable(dpl)
 


### PR DESCRIPTION
oneDPL-2022.1.0-rc3 already contains @rscohn2 fix for unused variable in its latest commit (https://github.com/oneapi-src/oneDPL/commit/6f1c27bfd1cefe1d3b49b7cbff1ffd81234e50c7)

I propose to switch back to official version of oneDPL, although it is still a release-candidate.