### PR TITLE
mhp dot product, 1 rank for ci

### DIFF
--- a/examples/mhp/CMakeLists.txt
+++ b/examples/mhp/CMakeLists.txt
@@ -9,7 +9,7 @@ if (ENABLE_SYCL)
   add_executable(mhp_dot_product_benchmark dot_product_benchmark.cpp)
   target_compile_options(mhp_dot_product_benchmark PRIVATE -fsycl)
   target_link_libraries(mhp_dot_product_benchmark DR::mpi cxxopts)
-  add_mpi_test(mhp_dot_product mhp_dot_product_benchmark 2 -n 1000)
+  add_mpi_test(mhp_dot_product mhp_dot_product_benchmark 1 -n 1000)
 endif()
 
 add_executable(vector-add vector-add.cpp)


### PR DESCRIPTION
Another attempt to prevent the signal 9 failures in github ci.