### PR TITLE
fix benchmarking issues

### DIFF
--- a/benchmarks/gbench/common/distributed_vector.cpp
+++ b/benchmarks/gbench/common/distributed_vector.cpp
@@ -14,20 +14,22 @@
 using T = double;
 
 static void Fill_DR(benchmark::State &state) {
-  xhp::distributed_vector<T> vec(default_vector_size);
+  T init = 0;
+  xhp::distributed_vector<T> vec(default_vector_size, init);
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
-      xhp::fill(vec, 0);
+      xhp::fill(vec, init);
     }
   }
   memory_bandwidth(state,
                    default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Fill_DR);
+BENCHMARK(Fill_DR)->UseRealTime();
 
 static void Fill_Local(benchmark::State &state) {
-  std::vector<T> vec(default_vector_size);
+  T init = 0;
+  std::vector<T> vec(default_vector_size, init);
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       rng::fill(vec, 0);
@@ -37,7 +39,42 @@ static void Fill_Local(benchmark::State &state) {
                    default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Fill_Local);
+BENCHMARK(Fill_Local)->UseRealTime();
+
+#ifdef SYCL_LANGUAGE_VERSION
+
+static void Fill_QueueFill_SYCL(benchmark::State &state) {
+  sycl::queue q;
+  T init = 0;
+  auto dst = sycl::malloc_device<T>(default_vector_size, q);
+  q.fill(dst, init, default_vector_size).wait();
+  for (auto _ : state) {
+    q.fill(dst, init, default_vector_size).wait();
+  }
+  memory_bandwidth(state,
+                   default_repetitions * default_vector_size * sizeof(T));
+}
+
+BENCHMARK(Fill_QueueFill_SYCL)->UseRealTime();
+
+static void Fill_ParallelFor_SYCL(benchmark::State &state) {
+  sycl::queue q;
+  T init = 0;
+  auto dst = sycl::malloc_device<T>(default_vector_size, q);
+  q.fill(dst, init, default_vector_size).wait();
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < default_repetitions; i++) {
+      q.parallel_for(default_vector_size, [=](auto index) {
+         dst[index] = init;
+       }).wait();
+    }
+  }
+  memory_bandwidth(state,
+                   default_repetitions * default_vector_size * sizeof(T));
+}
+
+BENCHMARK(Fill_ParallelFor_SYCL)->UseRealTime();
+#endif
 
 #ifndef BENCH_SHP
 // Not defined?
@@ -54,7 +91,7 @@ static void Copy_DR(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Copy_DR);
+BENCHMARK(Copy_DR)->UseRealTime();
 #endif
 
 static void Copy_Local(benchmark::State &state) {
@@ -69,7 +106,7 @@ static void Copy_Local(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Copy_Local);
+BENCHMARK(Copy_Local)->UseRealTime();
 
 static void Reduce_DR(benchmark::State &state) {
   xhp::distributed_vector<T> src(default_vector_size);
@@ -83,7 +120,7 @@ static void Reduce_DR(benchmark::State &state) {
                    default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Reduce_DR);
+BENCHMARK(Reduce_DR)->UseRealTime();
 
 static void Reduce_Local(benchmark::State &state) {
   std::vector<T> src(default_vector_size);
@@ -97,7 +134,7 @@ static void Reduce_Local(benchmark::State &state) {
                    default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Reduce_Local);
+BENCHMARK(Reduce_Local)->UseRealTime();
 
 #ifdef SYCL_LANGUAGE_VERSION
 static void Reduce_DPL(benchmark::State &state) {
@@ -114,7 +151,7 @@ static void Reduce_DPL(benchmark::State &state) {
                    default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Reduce_DPL);
+BENCHMARK(Reduce_DPL)->UseRealTime();
 #endif
 
 static void TransformIdentity_DR(benchmark::State &state) {
@@ -129,7 +166,7 @@ static void TransformIdentity_DR(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(TransformIdentity_DR);
+BENCHMARK(TransformIdentity_DR)->UseRealTime();
 
 static void TransformIdentity_Local(benchmark::State &state) {
   std::vector<T> src(default_vector_size);
@@ -143,7 +180,7 @@ static void TransformIdentity_Local(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(TransformIdentity_Local);
+BENCHMARK(TransformIdentity_Local)->UseRealTime();
 
 #ifndef BENCH_SHP
 // segfault
@@ -165,7 +202,7 @@ static void Mul_DR(benchmark::State &state) {
                    3 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Mul_DR);
+BENCHMARK(Mul_DR)->UseRealTime();
 #endif
 
 static void Mul_Local(benchmark::State &state) {
@@ -183,4 +220,4 @@ static void Mul_Local(benchmark::State &state) {
                    3 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Mul_Local);
+BENCHMARK(Mul_Local)->UseRealTime();

--- a/benchmarks/gbench/common/dot_product.cpp
+++ b/benchmarks/gbench/common/dot_product.cpp
@@ -48,7 +48,7 @@ static void DotProduct_ZipReduce_DR(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(DotProduct_ZipReduce_DR);
+BENCHMARK(DotProduct_ZipReduce_DR)->UseRealTime();
 
 static void DotProduct_ZipReduce_Std(benchmark::State &state) {
   std::vector<T> a(default_vector_size, init_val);
@@ -71,7 +71,7 @@ static void DotProduct_ZipReduce_Std(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(DotProduct_ZipReduce_Std);
+BENCHMARK(DotProduct_ZipReduce_Std)->UseRealTime();
 
 static void DotProduct_TransformReduce_Std(benchmark::State &state) {
   std::vector<T> a(default_vector_size, init_val);
@@ -91,7 +91,7 @@ static void DotProduct_TransformReduce_Std(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(DotProduct_TransformReduce_Std);
+BENCHMARK(DotProduct_TransformReduce_Std)->UseRealTime();
 
 static void DotProduct_Loop_Std(benchmark::State &state) {
   std::vector<T> a(default_vector_size, init_val);
@@ -112,7 +112,7 @@ static void DotProduct_Loop_Std(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(DotProduct_Loop_Std);
+BENCHMARK(DotProduct_Loop_Std)->UseRealTime();
 
 #ifdef SYCL_LANGUAGE_VERSION
 static void DotProduct_TransformReduce_DPL(benchmark::State &state) {
@@ -140,5 +140,5 @@ static void DotProduct_TransformReduce_DPL(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(DotProduct_TransformReduce_DPL);
+BENCHMARK(DotProduct_TransformReduce_DPL)->UseRealTime();
 #endif

--- a/benchmarks/gbench/mhp/chunk.cpp
+++ b/benchmarks/gbench/mhp/chunk.cpp
@@ -24,7 +24,7 @@ static void Chunk_1DLoop_Std(benchmark::State &state) {
     }
   }
 }
-BENCHMARK(Chunk_1DLoop_Std);
+BENCHMARK(Chunk_1DLoop_Std)->UseRealTime();
 
 static void Chunk_2DLoop_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -39,7 +39,7 @@ static void Chunk_2DLoop_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Chunk_2DLoop_Std);
+BENCHMARK(Chunk_2DLoop_Std)->UseRealTime();
 
 static void Chunk_2DIndex_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -58,7 +58,7 @@ static void Chunk_2DIndex_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Chunk_2DIndex_Std);
+BENCHMARK(Chunk_2DIndex_Std)->UseRealTime();
 
 static void Chunk_2DIters_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -74,7 +74,7 @@ static void Chunk_2DIters_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Chunk_2DIters_Std);
+BENCHMARK(Chunk_2DIters_Std)->UseRealTime();
 
 static void ChunkFlattened_1DIters_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -90,7 +90,7 @@ static void ChunkFlattened_1DIters_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(ChunkFlattened_1DIters_Std);
+BENCHMARK(ChunkFlattened_1DIters_Std)->UseRealTime();
 
 static void ChunkFlattened_ForEach_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -104,7 +104,7 @@ static void ChunkFlattened_ForEach_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(ChunkFlattened_ForEach_Std);
+BENCHMARK(ChunkFlattened_ForEach_Std)->UseRealTime();
 
 static void ChunkTransformFlatten_ForEach_Std(benchmark::State &state) {
   auto size = num_rows * num_columns;
@@ -124,4 +124,4 @@ static void ChunkTransformFlatten_ForEach_Std(benchmark::State &state) {
   }
 }
 
-BENCHMARK(ChunkTransformFlatten_ForEach_Std);
+BENCHMARK(ChunkTransformFlatten_ForEach_Std)->UseRealTime();

--- a/benchmarks/gbench/mhp/mpi.cpp
+++ b/benchmarks/gbench/mhp/mpi.cpp
@@ -9,7 +9,7 @@ static void Barrier(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Barrier)->Iterations(1000000);
+BENCHMARK(Barrier)->Iterations(1000000)->UseRealTime();
 
 static void Fence(benchmark::State &state) {
   for (auto _ : state) {
@@ -17,4 +17,4 @@ static void Fence(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Fence)->Iterations(100000000);
+BENCHMARK(Fence)->Iterations(100000000)->UseRealTime();

--- a/benchmarks/gbench/mhp/rooted.cpp
+++ b/benchmarks/gbench/mhp/rooted.cpp
@@ -18,7 +18,7 @@ static void CopyDist2Local_DR(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(CopyDist2Local_DR);
+BENCHMARK(CopyDist2Local_DR)->UseRealTime();
 
 static void CopyLocal2Dist_DR(benchmark::State &state) {
   std::vector<T> src(default_vector_size);
@@ -32,4 +32,4 @@ static void CopyLocal2Dist_DR(benchmark::State &state) {
                    2 * default_repetitions * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(CopyLocal2Dist_DR);
+BENCHMARK(CopyLocal2Dist_DR)->UseRealTime();

--- a/benchmarks/gbench/mhp/stencil_1d.cpp
+++ b/benchmarks/gbench/mhp/stencil_1d.cpp
@@ -39,7 +39,7 @@ static void Stencil1D_Slide_Std(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Stencil1D_Slide_Std);
+BENCHMARK(Stencil1D_Slide_Std)->UseRealTime();
 
 auto stencil1d_subrange_op = [](auto &center) {
   auto win = &center;
@@ -62,7 +62,7 @@ static void Stencil1D_Subrange_Std(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Stencil1D_Subrange_Std);
+BENCHMARK(Stencil1D_Subrange_Std)->UseRealTime();
 
 static void Stencil1D_Subrange_DR(benchmark::State &state) {
   auto dist = dr::mhp::distribution().halo(1);
@@ -82,7 +82,7 @@ static void Stencil1D_Subrange_DR(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Stencil1D_Subrange_DR);
+BENCHMARK(Stencil1D_Subrange_DR)->UseRealTime();
 
 #ifdef SYCL_LANGUAGE_VERSION
 static void Stencil1D_Subrange_DPL(benchmark::State &state) {
@@ -105,5 +105,5 @@ static void Stencil1D_Subrange_DPL(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * default_vector_size * sizeof(T));
 }
 
-BENCHMARK(Stencil1D_Subrange_DPL);
+BENCHMARK(Stencil1D_Subrange_DPL)->UseRealTime();
 #endif

--- a/benchmarks/gbench/mhp/stencil_2d.cpp
+++ b/benchmarks/gbench/mhp/stencil_2d.cpp
@@ -146,7 +146,7 @@ static void Stencil2D_Loop_Serial(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * rows * cols * sizeof(T));
 }
 
-BENCHMARK(Stencil2D_Loop_Serial);
+BENCHMARK(Stencil2D_Loop_Serial)->UseRealTime();
 
 auto stencil_foreach_stdArray_op = [](auto &&v) {
   auto &[in_row, out_row] = v;
@@ -194,7 +194,7 @@ static void Stencil2D_ForeachStdArray_DR(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * rows * cols * sizeof(T));
 }
 
-BENCHMARK(Stencil2D_ForeachStdArray_DR);
+BENCHMARK(Stencil2D_ForeachStdArray_DR)->UseRealTime();
 
 //
 // Distributed vector of floats. Granularity ensures segments contain
@@ -233,7 +233,7 @@ static void Stencil2D_NocollectiveCPU_DR(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * rows * cols * sizeof(T));
 }
 
-BENCHMARK(Stencil2D_NocollectiveCPU_DR);
+BENCHMARK(Stencil2D_NocollectiveCPU_DR)->UseRealTime();
 
 // Under construction
 #if 0
@@ -283,7 +283,7 @@ static void Stencil2D_1DArrayTransform_DR(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Stencil2D_1DArrayTransform_DR);
+BENCHMARK(Stencil2D_1DArrayTransform_DR)->UseRealTime();
 #endif
 
 //
@@ -321,7 +321,7 @@ static void Stencil2D_Basic_SYCL(benchmark::State &state) {
   memory_bandwidth(state, 2 * stencil_steps * rows * cols * sizeof(T));
 }
 
-BENCHMARK(Stencil2D_Basic_SYCL);
+BENCHMARK(Stencil2D_Basic_SYCL)->UseRealTime();
 
 //
 // Distributed vector of floats. Granularity ensures segments contain
@@ -362,8 +362,9 @@ static void Stencil2D_NocollectiveSYCL_DR(benchmark::State &state) {
     }
     checker.check(stencil_steps % 2 ? b : a);
   }
+  memory_bandwidth(state, 2 * stencil_steps * rows * cols * sizeof(T));
 }
 
-BENCHMARK(Stencil2D_NocollectiveSYCL_DR);
+BENCHMARK(Stencil2D_NocollectiveSYCL_DR)->UseRealTime();
 
 #endif


### PR DESCRIPTION
When benchmarking, use wall clock time instead of main thread time. SYCL CPU runtime is multi-threaded. Fixes the issue with SHP fill appearing to get 5 TB/s memory bandwidth.