### PR TITLE
Fix copy

### DIFF
--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(
   shp-tests
   shp-tests.cpp
   ../common/all.cpp
-  # need to implement same API as MHP
   ../common/copy.cpp
   ../common/counted.cpp
   ../common/distributed_vector.cpp

--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(
   shp-tests.cpp
   ../common/all.cpp
   # need to implement same API as MHP
-  #../common/copy.cpp
+  ../common/copy.cpp
   ../common/counted.cpp
   ../common/distributed_vector.cpp
   ../common/drop.cpp


### PR DESCRIPTION
Implement distributed -> distributed version of `shp::copy`, as well as range-based interface, and enable shared copy tests for `shp`.