### PR TITLE
Implement Black-Scholes benchmark

### DIFF
--- a/examples/shp/CMakeLists.txt
+++ b/examples/shp/CMakeLists.txt
@@ -35,3 +35,4 @@ add_shp_example_no_test(matrix_example)  # PI_ERROR_DEVICE_NOT_FOUND
 add_shp_example(sparse_test)
 add_shp_example_no_test(take_example)  # PI_ERROR_DEVICE_NOT_FOUND
 add_shp_example_no_test(zip_example)  # PI_ERROR_DEVICE_NOT_FOUND
+add_shp_example_no_test(black_scholes_benchmark)  # PI_ERROR_DEVICE_NOT_FOUND

--- a/examples/shp/black_scholes_benchmark.cpp
+++ b/examples/shp/black_scholes_benchmark.cpp
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cmath>
+#include <concepts>
+#include <dr/shp.hpp>
+#include <vector>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+namespace shp = dr::shp;
+
+template <typename T> static T RandFloat(T a, T b) {
+  return drand48() / std::numeric_limits<T>::max() * (b - a) + a;
+}
+
+template <typename T> auto InitData(std::size_t nopt) {
+  std::vector<T> s0(nopt);
+  std::vector<T> x(nopt);
+  std::vector<T> t(nopt);
+  std::vector<T> vcall(nopt);
+  std::vector<T> vput(nopt);
+  int i;
+
+  constexpr T S0L = 10;
+  constexpr T S0H = 50;
+  constexpr T XL = 10;
+  constexpr T XH = 50;
+  constexpr T TL = 1;
+  constexpr T TH = 2;
+
+/* NUMA-friendly data init */
+#pragma omp parallel for ordered
+  for (i = 0; i < nopt; i++) {
+#pragma omp ordered
+    {
+      s0[i] = RandFloat(S0L, S0H);
+      x[i] = RandFloat(XL, XH);
+      t[i] = RandFloat(TL, TH);
+    }
+
+    vcall[i] = 0;
+    vput[i] = 0;
+  }
+  return std::tuple(s0, x, t, vcall, vput);
+}
+
+template <typename T, typename U> bool is_equal(T &&x, U &&y) { return x == y; }
+
+template <std::floating_point T>
+bool is_equal(T a, T b, T epsilon = 128 * std::numeric_limits<T>::epsilon()) {
+  if (a == b) {
+    return true;
+  }
+
+  auto abs_th = std::numeric_limits<T>::min();
+
+  auto diff = std::abs(a - b);
+
+  auto norm =
+      std::min((std::abs(a) + std::abs(b)), std::numeric_limits<float>::max());
+  return diff < std::max(abs_th, epsilon * norm);
+}
+
+template <rng::forward_range A, rng::forward_range B>
+bool is_equal(A &&a, B &&b) {
+  for (auto &&[x, y] : rng::views::zip(a, b)) {
+    if (!is_equal(x, y)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <rng::range R> void fill_random(R &&r) {
+  for (auto &&v : r) {
+    v = drand48();
+  }
+}
+
+template <std::floating_point T> T normalCDF(T x) {
+  return std::erfc(-x / std::sqrt(2)) / 2;
+}
+
+template <typename T, rng::range RS, rng::range RX, rng::range RT,
+          rng::range RC, rng::range RP>
+void black_scholes(T r, T sig, RS &&s0, RX &&x, RT &&t, RC &&vcall, RP &&vput) {
+
+  std::size_t nopt = rng::size(s0);
+
+  for (std::size_t i = 0; i < nopt; i++) {
+    T d1 = (std::log(s0[i] / x[i]) + (r + T(0.5) * sig * sig) * t[i]) /
+           (sig * std::sqrt(t[i]));
+    T d2 = (std::log(s0[i] / x[i]) + (r - T(0.5) * sig * sig) * t[i]) /
+           (sig * std::sqrt(t[i]));
+
+    vcall[i] =
+        s0[i] * normalCDF(d1) - std::exp(-r * t[i]) * x[i] * normalCDF(d2);
+    vput[i] =
+        std::exp(-r * t[i]) * x[i] * normalCDF(-d2) - s0[i] * normalCDF(-d1);
+  }
+}
+
+template <typename T, rng::range RS, rng::range RX, rng::range RT,
+          rng::range RC, rng::range RP>
+void black_scholes_functional(T r, T sig, RS &&s0, RX &&x, RT &&t, RC &&vcall,
+                              RP &&vput) {
+
+  auto black_scholes = [=](auto &&e) {
+    auto &&[s0, x, t, vcall, vput] = e;
+    T d1 = (std::log(s0 / x) + (r + T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+    T d2 = (std::log(s0 / x) + (r - T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+
+    vcall = s0 * normalCDF(d1) - std::exp(-r * t) * x * normalCDF(d2);
+    vput = std::exp(-r * t) * x * normalCDF(-d2) - s0 * normalCDF(-d1);
+  };
+
+  auto zipped_view = rng::views::zip(s0, x, t, vcall, vput);
+
+  std::for_each(zipped_view.begin(), zipped_view.end(), black_scholes);
+}
+
+template <typename Policy, typename T, rng::range RS, rng::range RX,
+          rng::range RT, rng::range RC, rng::range RP>
+void black_scholes_onedpl(Policy &&policy, T r, T sig, RS &&s0, RX &&x, RT &&t,
+                          RC &&vcall, RP &&vput) {
+
+  auto black_scholes = [=](auto &&e) {
+    auto &&[s0, x, t, vcall, vput] = e;
+    T d1 = (std::log(s0 / x) + (r + T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+    T d2 = (std::log(s0 / x) + (r - T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+
+    vcall = s0 * normalCDF(d1) - std::exp(-r * t) * x * normalCDF(d2);
+    vput = std::exp(-r * t) * x * normalCDF(-d2) - s0 * normalCDF(-d1);
+  };
+
+  auto zipped_view = rng::views::zip(s0, x, t, vcall, vput);
+
+  dr::__detail::direct_iterator d_first(zipped_view.begin());
+  dr::__detail::direct_iterator d_last(zipped_view.end());
+
+  oneapi::dpl::experimental::for_each_async(policy, d_first, d_last,
+                                            black_scholes)
+      .wait();
+}
+
+template <dr::distributed_iterator Iter> void iter(Iter it) {}
+
+template <dr::distributed_range R> void range(R &&) {}
+
+template <typename T, dr::distributed_range RS, dr::distributed_range RX,
+          dr::distributed_range RT, dr::distributed_range RC,
+          dr::distributed_range RP>
+void black_scholes_distributed(T r, T sig, RS &&s0, RX &&x, RT &&t, RC &&vcall,
+                               RP &&vput) {
+
+  auto black_scholes = [=](auto &&e) {
+    auto &&[s0, x, t, vcall, vput] = e;
+    T d1 = (std::log(s0 / x) + (r + T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+    T d2 = (std::log(s0 / x) + (r - T(0.5) * sig * sig) * t) /
+           (sig * std::sqrt(t));
+
+    vcall = s0 * normalCDF(d1) - std::exp(-r * t) * x * normalCDF(d2);
+    vput = std::exp(-r * t) * x * normalCDF(-d2) - s0 * normalCDF(-d1);
+  };
+
+  auto zipped_view = shp::views::zip(s0, x, t, vcall, vput);
+
+  shp::for_each(zipped_view, black_scholes);
+}
+
+int main(int argc, char **argv) {
+  shp::init(sycl::gpu_selector_v);
+
+  std::size_t n = 2ll * 1024 * 1024 * 1024;
+  using T = float;
+
+  // Risk-free rate
+  T r = 0.1;
+  // Volatility
+  T sig = 0.2;
+
+  fmt::print("Initializing arrays...\n");
+
+  auto &&[s0, x, t, vcall, vput] = InitData<T>(n);
+
+  shp::distributed_vector<T> d_s0(n);
+  shp::distributed_vector<T> d_x(n);
+
+  shp::distributed_vector<T> d_t(n);
+  shp::distributed_vector<T> d_vcall(n);
+  shp::distributed_vector<T> d_vput(n);
+
+  shp::copy(s0.begin(), s0.end(), d_s0.begin());
+  shp::copy(x.begin(), x.end(), d_x.begin());
+  shp::copy(t.begin(), t.end(), d_t.begin());
+  shp::copy(vcall.begin(), vcall.end(), d_vcall.begin());
+  shp::copy(vput.begin(), vput.end(), d_vput.begin());
+
+  black_scholes_distributed(r, sig, d_s0, d_x, d_t, d_vcall, d_vput);
+
+  black_scholes_functional(r, sig, s0, x, t, vcall, vput);
+
+  std::size_t n_iterations = 10;
+
+  std::vector<double> durations;
+
+  T sum = 0;
+
+  fmt::print("Executing distributed...\n");
+  for (std::size_t i = 0; i < n_iterations; i++) {
+    auto begin = std::chrono::high_resolution_clock::now();
+    black_scholes_distributed(r, sig, d_s0, d_x, d_t, d_vcall, d_vput);
+    auto end = std::chrono::high_resolution_clock::now();
+    double duration = std::chrono::duration<double>(end - begin).count();
+
+    sum += shp::reduce(d_vcall);
+    sum += shp::reduce(d_vput);
+    durations.push_back(duration);
+  }
+
+  fmt::print("Sum: {}\n", sum);
+
+  fmt::print("Durations: {}\n", durations);
+
+  std::sort(durations.begin(), durations.end());
+
+  double median_duration = durations[durations.size() / 2];
+
+  std::cout << "Distributed Black-Scholes: " << median_duration * 1000 << " ms"
+            << std::endl;
+
+  durations.clear();
+
+  if (n < 1 * 1000 * 1000 * 1000) {
+    fmt::print("Executing serial Black-Scholes...\n");
+
+    sum = 0;
+    for (std::size_t i = 0; i < n_iterations; i++) {
+      auto begin = std::chrono::high_resolution_clock::now();
+      black_scholes(r, sig, s0, x, t, vcall, vput);
+      auto end = std::chrono::high_resolution_clock::now();
+      double duration = std::chrono::duration<double>(end - begin).count();
+
+      sum += std::reduce(vcall.begin(), vcall.end());
+      sum += std::reduce(vput.begin(), vput.end());
+      durations.push_back(duration);
+    }
+
+    fmt::print("Sum: {}\n", sum);
+
+    fmt::print("Durations: {}\n", durations);
+
+    std::sort(durations.begin(), durations.end());
+
+    median_duration = durations[durations.size() / 2];
+
+    std::cout << "Single-threaded Black-Scholes: " << median_duration * 1000
+              << " ms" << std::endl;
+
+    durations.clear();
+  } else {
+    fmt::print("n > 1*1000*1000*1000, not running serial Black-Scholes\n");
+  }
+
+  {
+    auto &&q = shp::__detail::queue(0);
+    oneapi::dpl::execution::device_policy policy(q);
+
+    fmt::print("Allocating and copying over to device...\n");
+    T *p_s0 = sycl::malloc_device<T>(n, q);
+    T *p_x = sycl::malloc_device<T>(n, q);
+    T *p_t = sycl::malloc_device<T>(n, q);
+    T *p_vcall = sycl::malloc_device<T>(n, q);
+    T *p_vput = sycl::malloc_device<T>(n, q);
+
+    std::span<T> d_s0(p_s0, n);
+    std::span<T> d_x(p_x, n);
+    std::span<T> d_t(p_t, n);
+    std::span<T> d_vcall(p_vcall, n);
+    std::span<T> d_vput(p_vput, n);
+
+    shp::copy(s0.begin(), s0.end(), p_s0);
+    shp::copy(x.begin(), x.end(), p_x);
+    shp::copy(t.begin(), t.end(), p_t);
+    shp::copy(vcall.begin(), vcall.end(), p_vcall);
+    shp::copy(vput.begin(), vput.end(), p_vput);
+
+    fmt::print("Running...\n");
+    sum = 0;
+    for (std::size_t i = 0; i < n_iterations; i++) {
+      auto begin = std::chrono::high_resolution_clock::now();
+      black_scholes_onedpl(policy, r, sig, d_s0, d_x, d_t, d_vcall, d_vput);
+      auto end = std::chrono::high_resolution_clock::now();
+      double duration = std::chrono::duration<double>(end - begin).count();
+
+      sum += oneapi::dpl::reduce(policy, p_vcall, p_vcall + n);
+      // fmt::print("Sum 22...\n");
+      sum += oneapi::dpl::reduce(policy, p_vput, p_vput + n);
+      durations.push_back(duration);
+    }
+
+    fmt::print("Sum: {}\n", sum);
+
+    fmt::print("Durations: {}\n", durations);
+
+    std::sort(durations.begin(), durations.end());
+
+    median_duration = durations[durations.size() / 2];
+
+    std::cout << "oneDPL Black-Scholes: " << median_duration * 1000 << " ms"
+              << std::endl;
+
+    durations.clear();
+  }
+
+  return 0;
+}

--- a/include/dr/shp/util/sycl_utils.hpp
+++ b/include/dr/shp/util/sycl_utils.hpp
@@ -11,6 +11,25 @@ namespace dr::shp {
 
 namespace __detail {
 
+// This is a workaround to avoid performance degradation
+// in DPC++ for odd range sizes.
+template <typename Fn>
+sycl::event parallel_for_workaround(sycl::queue &q, sycl::range<1> numWorkItems,
+                                    Fn &&fn, std::size_t block_size = 128) {
+  std::size_t num_blocks = (numWorkItems.size() + block_size - 1) / block_size;
+
+  int32_t range_size = numWorkItems.size();
+
+  auto event = q.parallel_for(
+      sycl::nd_range<>(num_blocks * block_size, block_size), [=](auto nd_idx) {
+        auto idx = nd_idx.get_global_id(0);
+        if (idx < range_size) {
+          fn(idx);
+        }
+      });
+  return event;
+}
+
 template <typename Fn>
 sycl::event parallel_for_64bit(sycl::queue &q, sycl::range<1> numWorkItems,
                                Fn &&fn) {
@@ -22,7 +41,7 @@ sycl::event parallel_for_64bit(sycl::queue &q, sycl::range<1> numWorkItems,
     std::size_t launch_size =
         std::min(numWorkItems.size() - base_idx, max_kernel_size);
 
-    auto e = q.parallel_for(launch_size, [=](sycl::id<1> idx_) {
+    auto e = parallel_for_workaround(q, launch_size, [=](sycl::id<1> idx_) {
       sycl::id<1> idx(base_idx + idx_);
       fn(idx);
     });
@@ -44,7 +63,7 @@ sycl::event parallel_for(sycl::queue &q, sycl::range<1> numWorkItems, Fn &&fn) {
   std::size_t max_kernel_size = std::numeric_limits<std::int32_t>::max();
 
   if (numWorkItems.size() < max_kernel_size) {
-    return q.parallel_for(numWorkItems, std::forward<Fn>(fn));
+    return parallel_for_workaround(q, numWorkItems, std::forward<Fn>(fn));
   } else {
     return parallel_for_64bit(q, numWorkItems, std::forward<Fn>(fn));
   }

--- a/include/dr/shp/zip_view.hpp
+++ b/include/dr/shp/zip_view.hpp
@@ -217,6 +217,12 @@ public:
     return dr::__detail::owning_view(std::move(segment_views));
   }
 
+  auto local() const noexcept
+    requires(!(dr::distributed_range<Rs> || ...))
+  {
+    return local_impl_(std::make_index_sequence<sizeof...(Rs)>());
+  }
+
   // If:
   //   - There is at least one remote range in the zip
   //   - There are no distributed ranges in the zip
@@ -229,6 +235,11 @@ public:
   }
 
 private:
+  template <std::size_t... Ints>
+  auto local_impl_(std::index_sequence<Ints...>) const noexcept {
+    return rng::views::zip(__detail::local(std::get<Ints>(views_))...);
+  }
+
   template <std::size_t I, typename R> std::size_t get_rank_impl_() const {
     static_assert(I < sizeof...(Rs));
     return dr::ranges::rank(get_view<I>());


### PR DESCRIPTION
Implement Black-Scholes benchmark using `shp`.

This is essentially a fancy SAXPY operation.  We execute a `for_each` algorithm over multiple zipped arrays, operating on the corresponding elements.

```c++
template <typename T, dr::distributed_range RS, dr::distributed_range RX,
          dr::distributed_range RT, dr::distributed_range RC,
          dr::distributed_range RP>
void black_scholes_distributed(T r, T sig, RS &&s0, RX &&x, RT &&t, RC &&vcall,
                               RP &&vput) {

  auto black_scholes = [=](auto &&e) {
    auto &&[s0, x, t, vcall, vput] = e;
    T d1 = (std::log(s0 / x) + (r + T(0.5) * sig * sig) * t) /
           (sig * std::sqrt(t));
    T d2 = (std::log(s0 / x) + (r - T(0.5) * sig * sig) * t) /
           (sig * std::sqrt(t));

    vcall = s0 * normalCDF(d1) - std::exp(-r * t) * x * normalCDF(d2);
    vput = std::exp(-r * t) * x * normalCDF(-d2) - s0 * normalCDF(-d1);
  };

  auto zipped_view = shp::views::zip(s0, x, t, vcall, vput);

  shp::for_each(zipped_view, black_scholes);
}
```