### PR TITLE
mdspan

### DIFF
--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -25,8 +25,27 @@ target_link_libraries(
   DR::mpi
 )
 
+# mhp-quick-bench is for development. By reducing the number of source
+# files, it builds much faster. Change the source files to match what
+# you need to test. It is OK to commit changes to the source file
+# list.
+
+add_executable(
+  mhp-quick-bench
+  mhp-bench.cpp
+  stencil_2d.cpp
+)
+target_compile_definitions(mhp-quick-bench PRIVATE BENCH_MHP)
+target_link_libraries(
+  mhp-quick-bench
+  benchmark::benchmark
+  cxxopts
+  DR::mpi
+)
+
 if (ENABLE_SYCL)
   target_compile_options(mhp-bench PRIVATE -fsycl)
+  target_compile_options(mhp-quick-bench PRIVATE -fsycl)
 endif()
 
 cmake_path(GET MPI_CXX_ADDITIONAL_INCLUDE_DIRS FILENAME MPI_IMPL)

--- a/benchmarks/gbench/mhp/stencil_2d.cpp
+++ b/benchmarks/gbench/mhp/stencil_2d.cpp
@@ -212,13 +212,12 @@ DR_BENCHMARK(Stencil2D_ForeachStdArray_DR);
 // Distributed vector of floats. Granularity ensures segments contain
 // whole rows. Explicitly process segments SPMD-style.
 //
-static void Stencil2D_NocollectiveCPU_DR(benchmark::State &state) {
+static void Stencil2D_Segmented_DR(benchmark::State &state) {
   auto [rows, cols] = shape(state);
   if (rows == 0) {
     return;
   }
 
-  fmt::print("Rows: {}, Cols: {}\n", rows, cols);
   auto dist = dr::mhp::distribution().halo(cols).granularity(cols);
   dr::mhp::distributed_vector<T> a(rows * cols, init_val, dist);
   dr::mhp::distributed_vector<T> b(rows * cols, init_val, dist);
@@ -247,7 +246,50 @@ static void Stencil2D_NocollectiveCPU_DR(benchmark::State &state) {
   }
 }
 
-DR_BENCHMARK(Stencil2D_NocollectiveCPU_DR);
+DR_BENCHMARK(Stencil2D_Segmented_DR);
+
+//
+// Distributed vector of floats. Granularity ensures segments contain
+// whole rows. Explicitly process segments SPMD-style.
+//
+static void Stencil2D_SegmentedMdspan_DR(benchmark::State &state) {
+  auto [rows, cols] = shape(state);
+  if (rows == 0) {
+    return;
+  }
+
+  auto dist = dr::mhp::distribution().halo(cols).granularity(cols);
+  dr::mhp::distributed_vector<T> a(rows * cols, init_val, dist);
+  dr::mhp::distributed_vector<T> b(rows * cols, init_val, dist);
+  auto a_inner = rng::subrange(a.begin() + cols, a.end() - cols);
+  auto b_inner = rng::subrange(b.begin() + cols, b.end() - cols);
+  Stats stats(state, sizeof(T) * a.size(), sizeof(T) * b.size());
+
+  md::extents extents(rows - 2, cols);
+  auto a_matrix = xhp::views::mdspan(a_inner, extents);
+  auto b_matrix = xhp::views::mdspan(b_inner, extents);
+  Checker checker;
+  auto in = dr::mhp::local_mdspan(a_matrix);
+  auto out = dr::mhp::local_mdspan(b_matrix);
+
+  for (auto _ : state) {
+    for (std::size_t s = 0; s < stencil_steps; s++) {
+      stats.rep();
+      dr::mhp::halo(stencil_steps % 2 ? b : a).exchange();
+      for (std::size_t i = 0; i < in.extents().extent(0); i++) {
+        for (std::size_t j = 1; j < cols - 1; j++) {
+          out(i, j) = (in(i - 1, j) + in(i, j - 1) + in(i, j) + in(i, j + 1) +
+                       in(i - 1, j)) /
+                      4;
+        }
+      }
+      std::swap(in, out);
+    }
+    checker.check(stencil_steps % 2 ? b : a);
+  }
+}
+
+DR_BENCHMARK(Stencil2D_SegmentedMdspan_DR);
 
 // Under construction
 #if 0

--- a/benchmarks/gbench/mhp/stencil_2d.cpp
+++ b/benchmarks/gbench/mhp/stencil_2d.cpp
@@ -248,6 +248,10 @@ static void Stencil2D_Segmented_DR(benchmark::State &state) {
 
 DR_BENCHMARK(Stencil2D_Segmented_DR);
 
+#if __GNUC__ == 10 && __GNUC_MINOR__ == 4
+// mdspan triggers gcc 10 bugs, skip these tests
+#else
+
 //
 // Distributed vector of floats. Granularity ensures segments contain
 // whole rows. Explicitly process segments SPMD-style.
@@ -290,6 +294,8 @@ static void Stencil2D_SegmentedMdspan_DR(benchmark::State &state) {
 }
 
 DR_BENCHMARK(Stencil2D_SegmentedMdspan_DR);
+
+#endif // Skip for gcc 10.4
 
 // Under construction
 #if 0

--- a/include/dr/detail/mdspan_shim.hpp
+++ b/include/dr/detail/mdspan_shim.hpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <experimental/mdspan>
+namespace md = std::experimental;

--- a/include/dr/mhp.hpp
+++ b/include/dr/mhp.hpp
@@ -62,6 +62,7 @@ namespace fmt {}
 #include <dr/mhp/views/zip.hpp>
 #include <dr/mhp/views/enumerate.hpp>
 #include <dr/mhp/views/sliding.hpp>
+#include <dr/mhp/views/mdspan.hpp>
 #include <dr/mhp/algorithms/copy.hpp>
 #include <dr/mhp/algorithms/fill.hpp>
 #include <dr/mhp/algorithms/for_each.hpp>

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -179,9 +179,6 @@ public:
 
     if (my_process_segment_index == segment_index_ + 1) {
 #ifndef SYCL_LANGUAGE_VERSION
-      fmt::print("segment size: {}\n", dv_->segment_size_);
-      fmt::print("index: {}\n", index_);
-      fmt::print("halo prev: {}\n", dv_->distribution_.halo().prev);
       assert(dv_->segment_size_ - index_ <= dv_->distribution_.halo().prev);
 #endif
       return dv_->data_ + dv_->distribution_.halo().prev + index_ -

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -179,6 +179,9 @@ public:
 
     if (my_process_segment_index == segment_index_ + 1) {
 #ifndef SYCL_LANGUAGE_VERSION
+      fmt::print("segment size: {}\n", dv_->segment_size_);
+      fmt::print("index: {}\n", index_);
+      fmt::print("halo prev: {}\n", dv_->distribution_.halo().prev);
       assert(dv_->segment_size_ - index_ <= dv_->distribution_.halo().prev);
 #endif
       return dv_->data_ + dv_->distribution_.halo().prev + index_ -

--- a/include/dr/mhp/views/mdspan.hpp
+++ b/include/dr/mhp/views/mdspan.hpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <dr/detail/mdspan_shim.hpp>
+#include <dr/detail/ranges_shim.hpp>
+
+namespace dr::mhp {
+
+//
+// Mdspan uses this to access distributed range
+//
+template <typename Iter> class distributed_accessor {
+public:
+  using data_handle_type = Iter;
+  using reference = std::iter_reference_t<Iter>;
+  using offset_policy = distributed_accessor;
+
+  constexpr distributed_accessor() noexcept = default;
+  constexpr auto access(Iter iter, std::size_t index) const {
+    return iter[index];
+  }
+
+  constexpr auto offset(Iter iter, std::size_t index) const noexcept {
+    return iter + index;
+  }
+};
+
+template <distributed_contiguous_range R, typename Extents,
+          typename Layout = md::layout_right>
+class mdspan_view : public rng::view_interface<mdspan_view<R, Extents>> {
+private:
+  using base_type = rng::views::all_t<R>;
+  using iterator_type = rng::iterator_t<base_type>;
+  using mdspan_type = md::mdspan<iterator_type, Extents, Layout,
+                                 distributed_accessor<iterator_type>>;
+
+public:
+  mdspan_view(R r, Extents extents)
+      : base_(rng::views::all(r)), mdspan_(rng::begin(base_), extents) {}
+
+  auto begin() const { return base_.begin(); }
+  auto end() const { return base_.end(); }
+
+  auto segments() const { return dr::ranges::segments(base_); }
+
+  auto mdspan() const { return mdspan_; }
+
+private:
+  base_type base_;
+  mdspan_type mdspan_;
+};
+
+template <typename R, typename Extents>
+mdspan_view(R &&r, Extents extents)
+    -> mdspan_view<rng::views::all_t<R>, Extents>;
+
+} // namespace dr::mhp
+
+namespace dr::mhp::views {
+
+template <typename Extents> class mdspan_adapter_closure {
+public:
+  mdspan_adapter_closure(Extents extents) : extents_(extents) {}
+
+  template <rng::viewable_range R> auto operator()(R &&r) const {
+    return mdspan_view(std::forward<R>(r), extents_);
+  }
+
+  template <rng::viewable_range R>
+  friend auto operator|(R &&r, const mdspan_adapter_closure &closure) {
+    return closure(std::forward<R>(r));
+  }
+
+private:
+  Extents extents_;
+};
+
+class mdspan_fn_ {
+public:
+  template <rng::viewable_range R, typename Extents>
+  auto operator()(R &&r, Extents &&extents) const {
+    return mdspan_adapter_closure(std::forward<Extents>(extents))(
+        std::forward<R>(r));
+  }
+
+  template <typename Extents> auto operator()(Extents &&extents) const {
+    return mdspan_adapter_closure(std::forward<Extents>(extents));
+  }
+};
+
+inline constexpr auto mdspan = mdspan_fn_{};
+
+} // namespace dr::mhp::views

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(
 add_executable(
   mhp-quick-test
   mhp-tests.cpp
-  slide_view.cpp
+  mdstar.cpp
 )
 
 target_compile_definitions(mhp-quick-test PRIVATE QUICK_TEST)

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   alignment.cpp
   copy.cpp
   distributed_vector.cpp
+  mdstar.cpp
   reduce.cpp
   stencil.cpp
   segments.cpp
@@ -39,8 +40,10 @@ add_executable(
   slide_view-3.cpp
 )
 
-# mhp-quick-test is a skeleton for rapid builds of individual tests,
-# feel free to change this
+# mhp-quick-test is for development. By reducing the number of source
+# files, it builds much faster. Change the source files to match what
+# you need to test. It is OK to commit changes to the source file
+# list.
 
 add_executable(
   mhp-quick-test

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-tests.hpp"
+
+using T = int;
+
+const std::size_t rows = 2, cols = 5, n = rows * cols;
+md::extents extents(rows, cols);
+
+TEST(Mdspan, StaticAssert) {
+  xhp::distributed_vector<T> dist(n);
+  auto mdspan = xhp::views::mdspan(dist, extents);
+  static_assert(rng::forward_range<decltype(mdspan)>);
+  static_assert(dr::distributed_range<decltype(mdspan)>);
+}
+
+TEST(Mdspan, Iterator) {
+  xhp::distributed_vector<T> dist(n);
+  auto mdspan = xhp::views::mdspan(dist, extents);
+
+  *mdspan.begin() = 17;
+  EXPECT_EQ(17, *mdspan.begin());
+  EXPECT_EQ(17, dist[0]);
+}
+
+TEST(Mdspan, Mdindex) {
+  xhp::distributed_vector<T> dist(n);
+  auto dmdspan = xhp::views::mdspan(dist, extents);
+
+  std::size_t i = 1, j = 2;
+  dmdspan.mdspan()(i, j) = 17;
+  EXPECT_EQ(17, dist[i * cols + j]);
+  EXPECT_EQ(17, dmdspan.mdspan()(i, j));
+}

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -4,6 +4,10 @@
 
 #include "xhp-tests.hpp"
 
+#if __GNUC__ == 10 && __GNUC_MINOR__ == 4
+// mdspan triggers gcc 10 bugs, skip these tests
+#else
+
 using T = int;
 
 const std::size_t xdim = 4, ydim = 3, zdim = 2, n2d = xdim * ydim,
@@ -105,3 +109,4 @@ TEST(Mdspan, Subrange) {
   }
   EXPECT_EQ(extents2d.extent(0), x + 2);
 }
+#endif // Skip for gcc 10.4

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -46,3 +46,12 @@ TEST(Mdspan, Mdindex3D) {
   EXPECT_EQ(17, dist[i * ydim * zdim + j * zdim + k]);
   EXPECT_EQ(17, dmdspan.mdspan()(i, j, k));
 }
+
+TEST(Mdspan, Pipe) {
+  xhp::distributed_vector<T> dist(n2d);
+  auto mdspan = dist | xhp::views::mdspan(extents2d);
+
+  *mdspan.begin() = 17;
+  EXPECT_EQ(17, *mdspan.begin());
+  EXPECT_EQ(17, dist[0]);
+}

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -55,3 +55,14 @@ TEST(Mdspan, Pipe) {
   EXPECT_EQ(17, *mdspan.begin());
   EXPECT_EQ(17, dist[0]);
 }
+
+TEST(Mdspan, SegmentIndex2D) {
+  xhp::distributed_vector<T> dist(n2d);
+  auto dmdspan = xhp::views::mdspan(dist, extents2d);
+
+  for (auto segment : dr::ranges::segments(dmdspan)) {
+    static_assert(std::same_as<T *, decltype(&segment.mdspan()(0, 1))>);
+    segment.mdspan()(0, 1) = 99;
+    EXPECT_EQ(99, segment[1]);
+  }
+}

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -6,31 +6,43 @@
 
 using T = int;
 
-const std::size_t rows = 2, cols = 5, n = rows * cols;
-md::extents extents(rows, cols);
+const std::size_t xdim = 2, ydim = 3, zdim = 2, n2d = xdim * ydim,
+                  n3d = xdim * ydim * zdim;
+md::extents extents2d(xdim, ydim);
+md::extents extents3d(xdim, ydim, zdim);
 
 TEST(Mdspan, StaticAssert) {
-  xhp::distributed_vector<T> dist(n);
-  auto mdspan = xhp::views::mdspan(dist, extents);
+  xhp::distributed_vector<T> dist(n2d);
+  auto mdspan = xhp::views::mdspan(dist, extents2d);
   static_assert(rng::forward_range<decltype(mdspan)>);
   static_assert(dr::distributed_range<decltype(mdspan)>);
 }
 
 TEST(Mdspan, Iterator) {
-  xhp::distributed_vector<T> dist(n);
-  auto mdspan = xhp::views::mdspan(dist, extents);
+  xhp::distributed_vector<T> dist(n2d);
+  auto mdspan = xhp::views::mdspan(dist, extents2d);
 
   *mdspan.begin() = 17;
   EXPECT_EQ(17, *mdspan.begin());
   EXPECT_EQ(17, dist[0]);
 }
 
-TEST(Mdspan, Mdindex) {
-  xhp::distributed_vector<T> dist(n);
-  auto dmdspan = xhp::views::mdspan(dist, extents);
+TEST(Mdspan, Mdindex2D) {
+  xhp::distributed_vector<T> dist(n2d);
+  auto dmdspan = xhp::views::mdspan(dist, extents2d);
 
   std::size_t i = 1, j = 2;
   dmdspan.mdspan()(i, j) = 17;
-  EXPECT_EQ(17, dist[i * cols + j]);
+  EXPECT_EQ(17, dist[i * ydim + j]);
   EXPECT_EQ(17, dmdspan.mdspan()(i, j));
+}
+
+TEST(Mdspan, Mdindex3D) {
+  xhp::distributed_vector<T> dist(n3d);
+  auto dmdspan = xhp::views::mdspan(dist, extents3d);
+
+  std::size_t i = 1, j = 2, k = 0;
+  dmdspan.mdspan()(i, j, k) = 17;
+  EXPECT_EQ(17, dist[i * ydim * zdim + j * zdim + k]);
+  EXPECT_EQ(17, dmdspan.mdspan()(i, j, k));
 }

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -11,15 +11,18 @@ const std::size_t xdim = 4, ydim = 3, zdim = 2, n2d = xdim * ydim,
 md::extents extents2d(xdim, ydim);
 md::extents extents3d(xdim, ydim, zdim);
 
+auto dist2d = dr::mhp::distribution().granularity(ydim);
+auto dist3d = dr::mhp::distribution().granularity(ydim * zdim);
+
 TEST(Mdspan, StaticAssert) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto mdspan = xhp::views::mdspan(dist, extents2d);
   static_assert(rng::forward_range<decltype(mdspan)>);
   static_assert(dr::distributed_range<decltype(mdspan)>);
 }
 
 TEST(Mdspan, Iterator) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto mdspan = xhp::views::mdspan(dist, extents2d);
 
   *mdspan.begin() = 17;
@@ -28,7 +31,7 @@ TEST(Mdspan, Iterator) {
 }
 
 TEST(Mdspan, Mdindex2D) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto dmdspan = xhp::views::mdspan(dist, extents2d);
 
   std::size_t i = 1, j = 2;
@@ -38,7 +41,7 @@ TEST(Mdspan, Mdindex2D) {
 }
 
 TEST(Mdspan, Mdindex3D) {
-  xhp::distributed_vector<T> dist(n3d);
+  xhp::distributed_vector<T> dist(n3d, dist3d);
   auto dmdspan = xhp::views::mdspan(dist, extents3d);
 
   std::size_t i = 1, j = 2, k = 0;
@@ -48,7 +51,7 @@ TEST(Mdspan, Mdindex3D) {
 }
 
 TEST(Mdspan, Pipe) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto mdspan = dist | xhp::views::mdspan(extents2d);
 
   *mdspan.begin() = 17;
@@ -57,7 +60,7 @@ TEST(Mdspan, Pipe) {
 }
 
 TEST(Mdspan, SegmentIndex2D) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto dmdspan = xhp::views::mdspan(dist, extents2d);
 
   for (auto segment : dr::ranges::segments(dmdspan)) {
@@ -70,7 +73,7 @@ TEST(Mdspan, SegmentIndex2D) {
 }
 
 TEST(Mdspan, SegmentExtents) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto dmdspan = xhp::views::mdspan(dist, extents2d);
 
   // Summing up leading dimension size of segments should equal
@@ -86,7 +89,7 @@ TEST(Mdspan, SegmentExtents) {
 }
 
 TEST(Mdspan, Subrange) {
-  xhp::distributed_vector<T> dist(n2d);
+  xhp::distributed_vector<T> dist(n2d, dist2d);
   auto inner = rng::subrange(dist.begin() + ydim, dist.end() - ydim);
   md::extents inner_extents(extents2d.extent(0) - 2, extents2d.extent(1));
   auto dmdspan = xhp::views::mdspan(inner, inner_extents);

--- a/test/gtest/mhp/stencil.cpp
+++ b/test/gtest/mhp/stencil.cpp
@@ -12,7 +12,7 @@ using DVI = typename DV::iterator;
 const std::size_t radius = 4;
 const std::size_t n = 10;
 
-TEST(MhpTests, Stencil) {
+TEST(Stencil, 1D) {
   auto dist = dr::mhp::distribution().halo(radius);
   DV dv_in(n, dist);
   DV dv_out(n, dist);


### PR DESCRIPTION
Adds `mdspan_view` that provides a multi-dimensional (nD) view of a distributed contiguous range. The interface needs refinement to make programs more concise and intuitive. 

An mdspan_view is a distributed_range that supports 1 dimensional iteration. It also permits nD indexing of distributed data. The segments of a mdspan_view are remote ranges that also support nD indexing when the segment is local. nD indexing of a local segment is efficient--essentially the same as conventional nD Indexing with pointers.

There are many limitations. It has limited composability. When you apply other views to an mdspan_view, they compose with the underlying range and the nD indexing capability is lost. Algorithms also only see the 1D iterators.

The functionality is useful if you process segments manually instead of using parallel algorithms like for_each.