### PR TITLE
added exception in dr-style for .size() preceeded by comm variable

### DIFF
--- a/include/dr/mhp/algorithms/reduce.hpp
+++ b/include/dr/mhp/algorithms/reduce.hpp
@@ -57,7 +57,7 @@ auto reduce(std::size_t root, bool root_provided, DR &&dr, auto &&binary_op) {
     auto locals = rng::views::transform(local_segments(dr), reduce);
     auto local = std_reduce(locals, binary_op);
 
-    std::vector<value_type> all(comm.size()); // dr-style ignore
+    std::vector<value_type> all(comm.size());
     if (root_provided) {
       // Everyone gathers to root, only root reduces
       comm.gather(local, all, root);

--- a/scripts/dr-style.py
+++ b/scripts/dr-style.py
@@ -110,7 +110,7 @@ include_rules = [
         'use namespace __detail {',
     ),
     (
-        r'\.size\(\)',
+        r'(?<!comm)\.size\(\)',
         'use rng::size()',
     ),
     (

--- a/test/gtest/mhp/slide_view-3.cpp
+++ b/test/gtest/mhp/slide_view-3.cpp
@@ -10,7 +10,7 @@ template <typename T> class Slide3 : public testing::Test {};
 TYPED_TEST_SUITE(Slide3, AllTypes);
 
 TYPED_TEST(Slide3, suite_works_for_3_processes_only) {
-  EXPECT_EQ(dr::mhp::default_comm().size(), 3); // dr-style ignore
+  EXPECT_EQ(dr::mhp::default_comm().size(), 3);
 }
 
 TYPED_TEST(Slide3, no_sides) {


### PR DESCRIPTION
Sometimes it is not enough to write dr-style ignore comment because clang formatter puts `.size()` inside longer expression and comment is in next line. I think `comm.size()` can be allowed as a valid pattern of taking size of communicator.