### PR TITLE
mhp gpu selection: round robin among ranks

### DIFF
--- a/benchmarks/gbench/mhp/mhp-bench.cpp
+++ b/benchmarks/gbench/mhp/mhp-bench.cpp
@@ -30,7 +30,7 @@ public:
 void dr_init() {
 #ifdef SYCL_LANGUAGE_VERSION
   if (options.count("sycl")) {
-    sycl::queue q;
+    sycl::queue q = dr::mhp::select_queue();
     if (comm_rank == 0) {
       fmt::print("  SYCL device:\n");
       benchmark::AddCustomContext("device", device_info(q.get_device()));

--- a/include/dr/mhp/global.hpp
+++ b/include/dr/mhp/global.hpp
@@ -69,7 +69,28 @@ inline void init(sycl::queue q) {
          "Do not call mhp::init() more than once");
   __detail::global_context_ = new __detail::global_context(q);
 }
-#else
+
+inline sycl::queue select_queue() {
+  std::vector<sycl::device> devices;
+
+  auto root_devices = sycl::platform().get_devices();
+
+  for (auto &&root_device : root_devices) {
+    auto subdevices = root_device.create_sub_devices<
+        sycl::info::partition_property::partition_by_affinity_domain>(
+        sycl::info::partition_affinity_domain::numa);
+
+    for (auto &&subdevice : subdevices) {
+      devices.push_back(subdevice);
+    }
+  }
+
+  assert(rng::size(devices) > 0);
+  // Round robin assignment of devices to ranks
+  return sycl::queue(devices[default_comm().rank() % rng::size(devices)]);
+}
+
+#else // SYCL_LANGUAGE_VERSION
 inline auto sycl_queue() {
   assert(false);
   return 0;
@@ -78,7 +99,8 @@ inline const auto &dpl_policy() {
   assert(false);
   return std::execution::seq;
 }
-#endif
+
+#endif // SYCL_LANGUAGE_VERSION
 
 template <typename T> class default_allocator {
 


### PR DESCRIPTION
@jngkim Recommended adding this method for selecting GPU's for MHP. Previously, I was assuming that we would always be relying on external mechanisms like GPU pinning or resource managers to select GPU's, but @jngkim explained why that may not always work.

This algorithm should do the right thing for all cases of multi/single GPU, GPU pinning/ no pinning, partitionable devices/non partitionable.

@suyashbakshi: I did not test that it works on a multi-gpu system. Please fix it if you find problems.