### PR TITLE
fix gpu assignment for mhp

### DIFF
--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -50,5 +50,8 @@ if (NOT MPI_IMPL STREQUAL "openmpi")
   # 30000 is mininum because of static column size for stencil2D
   # disable DPL benchmarks because we get intermittent fails with:
   # ONEAPI_DEVICE_SELECTOR=opencl:cpu mpirun -n 1 ./mhp-bench --vector-size 30000 --rows 100 --columns 100 --check
-  add_mpi_test(mhp-bench-1 mhp-bench 1 --vector-size 30000 --rows 100 --columns 100 --check --benchmark_filter=-.*DPL.*)
+  add_mpi_test(mhp-bench-1 mhp-bench 1 --vector-size 30000 --rows 100 --columns 100 --check)
+  if(ENABLE_SYCL)
+    add_mpi_test(mhp-bench-1-sycl mhp-bench 1 --vector-size 30000 --rows 100 --columns 100 --check --benchmark_filter=-.*DPL.* --sycl)
+  endif()
 endif()

--- a/include/dr/mhp/global.hpp
+++ b/include/dr/mhp/global.hpp
@@ -70,7 +70,7 @@ inline void init(sycl::queue q) {
   __detail::global_context_ = new __detail::global_context(q);
 }
 
-inline sycl::queue select_queue() {
+inline sycl::queue select_queue(MPI_Comm comm = MPI_COMM_WORLD) {
   std::vector<sycl::device> devices;
 
   auto root_devices = sycl::platform().get_devices();
@@ -87,7 +87,8 @@ inline sycl::queue select_queue() {
 
   assert(rng::size(devices) > 0);
   // Round robin assignment of devices to ranks
-  return sycl::queue(devices[default_comm().rank() % rng::size(devices)]);
+  return sycl::queue(
+      devices[dr::communicator(comm).rank() % rng::size(devices)]);
 }
 
 #else // SYCL_LANGUAGE_VERSION


### PR DESCRIPTION
Fix a logic error in the earlier gpu pinning support. 

I assumed that it was being tested by mhp-bench tests, but we were not running mhp-bench with sycl enabled. Enabled mhp-bench  testing with --sycl. It found the problem. Thanks for @jngkim for tracking down the problem.