### PR TITLE
stencil_for_each: support arbitrary number of operands

### DIFF
--- a/benchmarks/gbench/mhp/stencil_2d.cpp
+++ b/benchmarks/gbench/mhp/stencil_2d.cpp
@@ -370,7 +370,7 @@ DR_BENCHMARK(Stencil2D_MdspanTuple_DR);
 // Distributed vector of floats. Granularity ensures segments contain
 // whole rows. Explicitly process segments SPMD-style.
 //
-static void Stencil2D_RadiusStencilForeach_DR(benchmark::State &state) {
+static void Stencil2D_StencilForeachRadius_DR(benchmark::State &state) {
   auto shape = default_shape();
   std::size_t radius = 1;
   if (shape[0] == 0) {
@@ -399,7 +399,7 @@ static void Stencil2D_RadiusStencilForeach_DR(benchmark::State &state) {
   }
 }
 
-DR_BENCHMARK(Stencil2D_RadiusStencilForeach_DR);
+DR_BENCHMARK(Stencil2D_StencilForeachRadius_DR);
 
 //
 // Distributed vector of floats. Granularity ensures segments contain

--- a/include/dr/mhp/algorithms/stencil_for_each.hpp
+++ b/include/dr/mhp/algorithms/stencil_for_each.hpp
@@ -61,14 +61,13 @@ void stencil_for_each(std::size_t radius, auto op,
 
 /// Collective for_each on distributed range
 template <typename... Ts>
-void stencil_for_each(auto op, dr::distributed_range auto &&dr1,
-                      dr::distributed_range auto &&dr2) {
+void stencil_for_each(auto op, dr::distributed_range auto &&...drs) {
+  auto &&dr1 = std::get<0>(std::tie(drs...));
   if (rng::empty(dr1)) {
     return;
   }
 
   auto grid1 = dr1.grid();
-  auto grid2 = dr2.grid();
 
   // TODO: Support distribution other than first dimension
   assert(grid1.extent(1) == 1);
@@ -76,21 +75,17 @@ void stencil_for_each(auto op, dr::distributed_range auto &&dr1,
     // If local
     if (tile_index == default_comm().rank()) {
       auto t1 = grid1(tile_index, 0).mdspan();
-      auto t2 = grid2(tile_index, 0).mdspan();
-      auto t1_root = grid1(tile_index, 0).root_mdspan();
-      auto t2_root = grid2(tile_index, 0).root_mdspan();
-
-      // TODO support arbitrary ranks
-      assert(t1.rank() == t2.rank() && t2.rank() == 2);
-      assert(t1.extents() == t2.extents());
 
       for (std::size_t i = 0; i < t1.extent(0); i++) {
         for (std::size_t j = 0; j < t1.extent(1); j++) {
-          auto t1_stencil =
-              md::mdspan(std::to_address(&t1(i, j)), t1_root.extents());
-          auto t2_stencil =
-              md::mdspan(std::to_address(&t2(i, j)), t2_root.extents());
-          op(std::tuple(t1_stencil, t2_stencil));
+          auto make_stencil = [=](auto &&dr) {
+            auto grid = dr.grid();
+            auto mdspan = grid(tile_index, 0).mdspan();
+            auto root_mdspan = grid(tile_index, 0).root_mdspan();
+            return md::mdspan(std::to_address(&mdspan(i, j)),
+                              root_mdspan.extents());
+          };
+          op(std::tuple(make_stencil(drs)...));
         }
       }
     }

--- a/include/dr/mhp/views/mdspan_view.hpp
+++ b/include/dr/mhp/views/mdspan_view.hpp
@@ -31,6 +31,7 @@ public:
 
   auto mdspan() const { return mdspan_; }
   auto origin() const { return origin_; }
+  auto root_mdspan() const { return mdspan(); }
 
 private:
   using T = rng::range_value_t<BaseSegment>;

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(mhp-tests-3 mhp-tests.cpp halo-3.cpp slide_view-3.cpp
 # builds much faster. Change the source files to match what you need to test. It
 # is OK to commit changes to the source file list.
 
-add_executable(mhp-quick-test mhp-tests.cpp ../common/inclusive_scan.cpp)
+add_executable(mhp-quick-test mhp-tests.cpp mdstar.cpp)
 
 target_compile_definitions(mhp-quick-test PRIVATE QUICK_TEST)
 

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -300,4 +300,36 @@ TEST_F(Submdspan, GridLocalReference) {
   EXPECT_EQ(99, mdarray[flat_index]) << mdrange_message(mdarray);
 }
 
+using StencilForeach = Mdspan;
+
+TEST_F(StencilForeach, 2ops) {
+  xhp::distributed_mdarray<T, 2> a(extents2d);
+  xhp::distributed_mdarray<T, 2> b(extents2d);
+  xhp::iota(a, 100);
+  xhp::iota(b, 200);
+  auto copy_op = [](auto v) {
+    auto [in, out] = v;
+    out(0, 0) = in(0, 0);
+  };
+
+  xhp::stencil_for_each(copy_op, a, b);
+  EXPECT_EQ(a.mdspan()(2, 2), b.mdspan()(2, 2));
+}
+
+TEST_F(StencilForeach, 3ops) {
+  xhp::distributed_mdarray<T, 2> a(extents2d);
+  xhp::distributed_mdarray<T, 2> b(extents2d);
+  xhp::distributed_mdarray<T, 2> c(extents2d);
+  xhp::iota(a, 100);
+  xhp::iota(b, 200);
+  xhp::iota(c, 200);
+  auto copy_op = [](auto v) {
+    auto [in1, in2, out] = v;
+    out(0, 0) = in1(0, 0) + in2(0, 0);
+  };
+
+  xhp::stencil_for_each(copy_op, a, b, c);
+  EXPECT_EQ(a.mdspan()(2, 2) + b.mdspan()(2, 2), c.mdspan()(2, 2));
+}
+
 #endif // Skip for gcc 10.4


### PR DESCRIPTION
Generalize stencil_for_each from 2 operands to support any number of operands. Verified that it has same stencil performance