### PR TITLE
shorter cmake lists of arguments, cmake-format config added

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Useful links about creating this config file:
+# https://cmake-format.readthedocs.io/en/latest/configuration.html
+# https://cmake-format.readthedocs.io/en/latest/configopts.html?highlight=layout_passes
+# https://cmake-format.readthedocs.io/en/latest/format-algorithm.html
+
+with section("format"):  # noqa: F821
+    layout_passes = {"PargGroupNode": [(0, False)]}

--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -6,17 +6,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(
   mhp-bench
-  mhp-bench.cpp
-  ../common/distributed_vector.cpp
-  ../common/dot_product.cpp
-  ../common/stream.cpp
-  ../common/black_scholes.cpp
-  rooted.cpp
-  stencil_1d.cpp
-  stencil_2d.cpp
-  chunk.cpp
-  mdspan.cpp
-  mpi.cpp)
+  mhp-bench.cpp ../common/distributed_vector.cpp ../common/dot_product.cpp
+  ../common/stream.cpp ../common/black_scholes.cpp rooted.cpp stencil_1d.cpp
+  stencil_2d.cpp chunk.cpp mdspan.cpp mpi.cpp)
 target_compile_definitions(mhp-bench PRIVATE BENCH_MHP)
 target_link_libraries(mhp-bench benchmark::benchmark cxxopts DR::mpi)
 
@@ -36,30 +28,12 @@ if(NOT MPI_IMPL STREQUAL "openmpi")
   # intermittent fails with: ONEAPI_DEVICE_SELECTOR=opencl:cpu mpirun -n 1
   # ./mhp-bench --vector-size 30000 --rows 100 --columns 100 --check
   add_mpi_test(
-    mhp-bench-1
-    mhp-bench
-    1
-    --vector-size
-    30000
-    --rows
-    100
-    --columns
-    100
+    mhp-bench-1 mhp-bench 1 --vector-size 30000 --rows 100 --columns 100
     --check)
   if(ENABLE_SYCL)
     add_mpi_test(
-      mhp-bench-1-sycl
-      mhp-bench
-      1
-      --vector-size
-      30000
-      --rows
-      100
-      --columns
-      100
-      --check
-      --benchmark_filter=-.*DPL.*
-      --sycl)
+      mhp-bench-1-sycl mhp-bench 1 --vector-size 30000 --rows 100 --columns 100
+      --check --benchmark_filter=-.*DPL.* --sycl)
   endif()
 endif()
 

--- a/test/fuzz/cpu/CMakeLists.txt
+++ b/test/fuzz/cpu/CMakeLists.txt
@@ -18,43 +18,18 @@ function(add_long_fuzz_mpi_test test_name name processes)
 endfunction()
 
 add_mpi_test(
-  cpu-fuzz-commit
-  cpu-fuzz
-  1
-  -max_len=16
-  -runs=1000000
-  -ignore_remaining_args=1
+  cpu-fuzz-commit cpu-fuzz 1 -max_len=16 -runs=1000000 -ignore_remaining_args=1
   -controller=1)
 
 add_long_fuzz_mpi_test(
-  cpu-fuzz-4-0
-  cpu-fuzz
-  4
-  -max_len=16
-  -runs=10000000
-  -ignore_remaining_args=1
+  cpu-fuzz-4-0 cpu-fuzz 4 -max_len=16 -runs=10000000 -ignore_remaining_args=1
   -controller=0)
 add_long_fuzz_mpi_test(
-  cpu-fuzz-4-1
-  cpu-fuzz
-  4
-  -max_len=16
-  -runs=10000000
-  -ignore_remaining_args=1
+  cpu-fuzz-4-1 cpu-fuzz 4 -max_len=16 -runs=10000000 -ignore_remaining_args=1
   -controller=1)
 add_long_fuzz_mpi_test(
-  cpu-fuzz-4-2
-  cpu-fuzz
-  4
-  -max_len=16
-  -runs=10000000
-  -ignore_remaining_args=1
+  cpu-fuzz-4-2 cpu-fuzz 4 -max_len=16 -runs=10000000 -ignore_remaining_args=1
   -controller=2)
 add_long_fuzz_mpi_test(
-  cpu-fuzz-4-3
-  cpu-fuzz
-  4
-  -max_len=16
-  -runs=10000000
-  -ignore_remaining_args=1
+  cpu-fuzz-4-3 cpu-fuzz 4 -max_len=16 -runs=10000000 -ignore_remaining_args=1
   -controller=3)

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -7,35 +7,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # tested with a variable number of ranks
 add_executable(
   mhp-tests
-  mhp-tests.cpp
-  ../common/all.cpp
-  ../common/copy.cpp
-  ../common/counted.cpp
-  ../common/distributed_vector.cpp
-  ../common/drop.cpp
-  ../common/enumerate.cpp
-  ../common/fill.cpp
-  ../common/for_each.cpp
-  ../common/inclusive_scan.cpp
-  ../common/iota.cpp
-  ../common/iota_view.cpp
-  ../common/reduce.cpp
-  ../common/subrange.cpp
-  ../common/take.cpp
-  ../common/transform.cpp
-  ../common/transform_view.cpp
-  ../common/zip.cpp
-  ../common/zip_local.cpp
-  alignment.cpp
-  copy.cpp
-  distributed_vector.cpp
-  distributed_dense_matrix.cpp
-  halo.cpp
-  mdstar.cpp
-  reduce.cpp
-  stencil.cpp
-  segments.cpp
-  slide_view.cpp)
+  mhp-tests.cpp ../common/all.cpp ../common/copy.cpp ../common/counted.cpp
+  ../common/distributed_vector.cpp ../common/drop.cpp ../common/enumerate.cpp
+  ../common/fill.cpp ../common/for_each.cpp ../common/inclusive_scan.cpp
+  ../common/iota.cpp ../common/iota_view.cpp ../common/reduce.cpp
+  ../common/subrange.cpp ../common/take.cpp ../common/transform.cpp
+  ../common/transform_view.cpp ../common/zip.cpp ../common/zip_local.cpp
+  alignment.cpp copy.cpp distributed_vector.cpp distributed_dense_matrix.cpp
+  halo.cpp mdstar.cpp reduce.cpp stencil.cpp segments.cpp slide_view.cpp)
 
 add_executable(mhp-tests-3 mhp-tests.cpp halo-3.cpp slide_view-3.cpp
                            distributed_dense_matrix3.cpp)

--- a/test/gtest/shp/CMakeLists.txt
+++ b/test/gtest/shp/CMakeLists.txt
@@ -6,30 +6,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(
   shp-tests
-  shp-tests.cpp
-  ../common/all.cpp
-  ../common/copy.cpp
-  ../common/counted.cpp
-  ../common/distributed_vector.cpp
-  ../common/drop.cpp
-  ../common/enumerate.cpp
-  ../common/fill.cpp
-  ../common/for_each.cpp
-  ../common/iota.cpp
+  shp-tests.cpp ../common/all.cpp ../common/copy.cpp ../common/counted.cpp
+  ../common/distributed_vector.cpp ../common/drop.cpp ../common/enumerate.cpp
+  ../common/fill.cpp ../common/for_each.cpp ../common/iota.cpp
   # ../common/iota_view.cpp
-  ../common/reduce.cpp
-  ../common/subrange.cpp
-  ../common/take.cpp
-  ../common/transform.cpp
-  ../common/transform_view.cpp
-  ../common/zip.cpp
-  ../common/zip_local.cpp
-  containers.cpp
-  algorithms.cpp
-  copy.cpp
-  fill.cpp
-  gemv.cpp
-  transform.cpp)
+  ../common/reduce.cpp ../common/subrange.cpp ../common/take.cpp
+  ../common/transform.cpp ../common/transform_view.cpp ../common/zip.cpp
+  ../common/zip_local.cpp containers.cpp algorithms.cpp copy.cpp fill.cpp
+  gemv.cpp transform.cpp)
 
 add_executable(shp-tests-3 shp-tests.cpp containers-3.cpp copy-3.cpp)
 


### PR DESCRIPTION
I'd like to improve https://github.com/oneapi-src/distributed-ranges/pull/377 by making cmake function calls concise and introduce  config file.

I think
```
add_mpi_test(
    mhp-bench-1 mhp-bench 1 --vector-size 30000 --rows 100 --columns 100
    --check)
```
looks better than
```
add_mpi_test(
    mhp-bench-1
    mhp-bench
    1
    --vector-size
    30000
    --rows
    100
    --columns
    100
    --check)
```
@rscohn2 , does my change look OK to you?