### PR TITLE
mdspan copy/pack/unpack/transpose

### DIFF
--- a/benchmarks/gbench/mhp/mdspan.cpp
+++ b/benchmarks/gbench/mhp/mdspan.cpp
@@ -15,7 +15,7 @@ static void MdspanUtil_Pack(benchmark::State &state) {
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       stats.rep();
-      dr::__detail::mdspan_pack(
+      dr::__detail::mdspan_copy(
           md::mdspan(a.data(), std::array{num_rows, num_columns}), b.begin());
     }
   }

--- a/include/dr/detail/mdspan_utils.hpp
+++ b/include/dr/detail/mdspan_utils.hpp
@@ -95,4 +95,26 @@ void mdspan_pack(M mdspan, std::forward_iterator auto iter) {
   mdspan_pack_impl(mdspan, iter, index, 0);
 }
 
+// For operator(), rearrange indices according to template arguments.
+//
+// For mdpermute<mdspan2d, 2, 1> a(b);
+//
+// a(3, 4) will do b(4, 3)
+//
+template <typename Mdspan, std::size_t... Is>
+class mdtranspose : public Mdspan {
+public:
+  // Inherit constructors from base class
+  mdtranspose(Mdspan &mdspan) : Mdspan(mdspan) {}
+
+  // rearrange indices according to template arguments
+  template <std::integral... Indexes> auto &operator()(Indexes... indexes) {
+    std::tuple index(indexes...);
+    return Mdspan::operator()(std::get<Is>(index)...);
+  }
+  auto &operator()(std::array<std::size_t, Mdspan::rank()> index) {
+    return Mdspan::operator()(index[Is]...);
+  }
+};
+
 } // namespace dr::__detail

--- a/include/dr/detail/mdspan_utils.hpp
+++ b/include/dr/detail/mdspan_utils.hpp
@@ -71,6 +71,24 @@ void mdspan_pack(M mdspan, std::forward_iterator auto iter) {
   mdspan_pack_impl(mdspan, iter, index, 0);
 }
 
+template <mdspan_like Src, mdspan_like Dst>
+void mdspan_copy_impl(Src src, Dst dst, dr_extents<Src::rank()> &index,
+                      std::size_t rank) {
+  for (index[rank] = 0; index[rank] < src.extent(rank); index[rank]++) {
+    if (rank == Src::rank() - 1) {
+      dst(index) = src(index);
+    } else {
+      mdspan_copy_impl(src, dst, index, rank + 1);
+    }
+  }
+}
+
+template <mdspan_like Src, mdspan_like Dst> void mdspan_copy(Src src, Dst dst) {
+  assert(src.extents() == dst.extents());
+  dr_extents<Src::rank()> index;
+  mdspan_copy_impl(src, dst, index, 0);
+}
+
 // For operator(), rearrange indices according to template arguments.
 //
 // For mdtranspose<mdspan2d, 1, 0> a(b);

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -368,7 +368,7 @@ TEST_F(MdStencilForeach, 3ops) {
 
 using MdspanUtil = Mdspan;
 
-TEST_F(MdspanUtil, pack) {
+TEST_F(MdspanUtil, Pack) {
   std::vector<T> a(xdim * ydim);
   std::vector<T> b(xdim * ydim);
   rng::iota(a, 100);
@@ -376,6 +376,27 @@ TEST_F(MdspanUtil, pack) {
 
   dr::__detail::mdspan_pack(md::mdspan(a.data(), extents2d), b.begin());
   EXPECT_EQ(a, b);
+}
+
+TEST_F(MdspanUtil, Transpose) {
+  std::vector<T> a(xdim * ydim);
+  std::vector<T> b(xdim * ydim);
+  rng::iota(a, 100);
+  rng::iota(b, 100);
+  md::mdspan mda(a.data(), extents2d);
+
+  // transpose view of mda
+  dr::__detail::mdtranspose<decltype(mda), 1, 0> mdat(mda);
+  EXPECT_EQ(mda(3, 1), mdat(1, 3));
+  EXPECT_EQ(mda(3, 1), mdat(std::array<std::size_t, 2>({1, 3})));
+  ;
+
+  fmt::print("mda:\n{}", mda);
+  // fmt::print("mdat:\n{}", mdat);
+  //  pack the transpose view into b
+  dr::__detail::mdspan_pack(mdat, b.begin());
+  EXPECT_EQ(a[3 * ydim + 1], b[1 * xdim + 3]);
+  fmt::print("B: {}\n", b);
 }
 
 #endif // Skip for gcc 10.4

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -375,7 +375,17 @@ TEST_F(MdspanUtil, Pack) {
   rng::iota(a, 100);
   rng::iota(b, 100);
 
-  dr::__detail::mdspan_pack(md::mdspan(a.data(), extents2d), b.begin());
+  dr::__detail::mdspan_copy(md::mdspan(a.data(), extents2d), b.begin());
+  EXPECT_EQ(a, b);
+}
+
+TEST_F(MdspanUtil, UnPack) {
+  std::vector<T> a(xdim * ydim);
+  std::vector<T> b(xdim * ydim);
+  rng::iota(a, 100);
+  rng::iota(b, 100);
+
+  dr::__detail::mdspan_copy(a.begin(), md::mdspan(b.data(), extents2d));
   EXPECT_EQ(a, b);
 }
 
@@ -407,7 +417,7 @@ TEST_F(MdspanUtil, Transpose) {
   EXPECT_EQ(mda(3, 1), mdat(std::array<std::size_t, 2>({1, 3}))) << tv_message;
 
   // Transpose pack
-  dr::__detail::mdspan_pack(mdat, b.begin());
+  dr::__detail::mdspan_copy(mdat, b.begin());
   EXPECT_EQ(a[3 * ydim + 1], b[1 * xdim + 3])
       << fmt::format("mdat:\n{}b:\n{}", mdat, b);
 

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -387,16 +387,14 @@ TEST_F(MdspanUtil, Transpose) {
 
   // transpose view of mda
   dr::__detail::mdtranspose<decltype(mda), 1, 0> mdat(mda);
-  EXPECT_EQ(mda(3, 1), mdat(1, 3));
-  EXPECT_EQ(mda(3, 1), mdat(std::array<std::size_t, 2>({1, 3})));
-  ;
+  auto message = fmt::format("mda:\n{}mdat:\n{}", mda, mdat);
+  EXPECT_EQ(mda(3, 1), mdat(1, 3)) << message;
+  EXPECT_EQ(mda(3, 1), mdat(std::array<std::size_t, 2>({1, 3}))) << message;
 
-  fmt::print("mda:\n{}", mda);
-  // fmt::print("mdat:\n{}", mdat);
   //  pack the transpose view into b
   dr::__detail::mdspan_pack(mdat, b.begin());
-  EXPECT_EQ(a[3 * ydim + 1], b[1 * xdim + 3]);
-  fmt::print("B: {}\n", b);
+  EXPECT_EQ(a[3 * ydim + 1], b[1 * xdim + 3])
+      << fmt::format("mdat:\n{}b:\n{}", mdat, b);
 }
 
 #endif // Skip for gcc 10.4


### PR DESCRIPTION
Primitives for manipulating local mdspan. To be used for 3d fft
* `mdspan_for_each `over index space of mdspan
* copies implemented with `mdspan_for_each`, works with mdspans that are slices (non-contiguous)
  * mdspan to mdspan
  * mdspan to contiguous container, pack data before send
  * contiguous container to mdspan, unpack data after receive
* multi-dimensional transpose view that can be combined with the copies to do out-of-place transpose