### PR TITLE
Generalize mdspan for_each to handle any number of dimensions

### DIFF
--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -22,7 +22,11 @@ target_link_libraries(mhp-bench benchmark::benchmark cxxopts DR::mpi)
 # builds much faster. Change the source files to match what you need to test. It
 # is OK to commit changes to the source file list.
 
-add_executable(mhp-quick-bench mhp-bench.cpp mdspan.cpp)
+# cmake-format: off
+add_executable(mhp-quick-bench mhp-bench.cpp
+  stencil_2d.cpp
+  )
+# cmake-format: on
 target_compile_definitions(mhp-quick-bench PRIVATE BENCH_MHP)
 target_link_libraries(mhp-quick-bench benchmark::benchmark cxxopts DR::mpi)
 


### PR DESCRIPTION
stencil_for_each and for_each over mdspans was limited to 2 dimensions. Now the CPU path supports any number of dimensions. SYCL support will be in a separate commit.