### PR TITLE
simplify md_foreach with tuple utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Test
       run: srun -p pvc-shared scripts/devcloud-run.sh
     - name: Benchmark
-      run: srun -p pvc scripts/devcloud-benchmarks.sh
+      run: srun -p pvc-shared scripts/devcloud-benchmarks.sh
     - uses: actions/upload-artifact@v3
       with:
         name: log-devcloud-bench

--- a/include/dr/detail/tuple_utils.hpp
+++ b/include/dr/detail/tuple_utils.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace dr::__detail {
+
+auto tuple_transform(auto tuple, auto op) {
+  auto transform = [op](auto &&...items) {
+    return std::make_tuple(op(items)...);
+  };
+  return std::apply(transform, tuple);
+}
+
+auto tuple_foreach(auto tuple, auto op) {
+  auto transform = [op](auto... items) { (op(items), ...); };
+  std::apply(transform, tuple);
+}
+
+} // namespace dr::__detail

--- a/include/dr/detail/tuple_utils.hpp
+++ b/include/dr/detail/tuple_utils.hpp
@@ -13,6 +13,13 @@ auto tuple_transform(auto tuple, auto op) {
   return std::apply(transform, tuple);
 }
 
+auto tie_transform(auto tuple, auto op) {
+  auto transform = [op]<typename... Items>(Items &&...items) {
+    return std::tie(op(std::forward<Items>(items))...);
+  };
+  return std::apply(transform, tuple);
+}
+
 auto tuple_foreach(auto tuple, auto op) {
   auto transform = [op](auto... items) { (op(items), ...); };
   std::apply(transform, tuple);

--- a/include/dr/mhp/algorithms/md_for_each.hpp
+++ b/include/dr/mhp/algorithms/md_for_each.hpp
@@ -13,14 +13,18 @@
 #include <dr/detail/logger.hpp>
 #include <dr/detail/onedpl_direct_iterator.hpp>
 #include <dr/detail/ranges_shim.hpp>
+#include <dr/detail/tuple_utils.hpp>
 #include <dr/mhp/global.hpp>
 
 namespace dr::mhp {
 
+namespace detail = dr::__detail;
+
 /// Collective for_each on distributed range
 template <typename... Ts>
 void stencil_for_each(auto op, is_mdspan_view auto &&...drs) {
-  auto &&dr1 = std::get<0>(std::tie(drs...));
+  auto ranges = std::tie(drs...);
+  auto &&dr1 = std::get<0>(ranges);
   if (rng::empty(dr1)) {
     return;
   }
@@ -32,30 +36,28 @@ void stencil_for_each(auto op, is_mdspan_view auto &&...drs) {
   for (std::size_t tile_index = 0; tile_index < grid1.extent(0); tile_index++) {
     // If local
     if (tile_index == default_comm().rank()) {
-      auto make_operand_info = [=](auto &&dr) {
-        auto tile = dr.grid()(tile_index, 0);
-        // mdspan for tile. This could be a submdspan, so we need the
-        // extents of the root to get the memory strides
-        return std::pair(tile.mdspan(), tile.root_mdspan().extents());
-      };
       // Calculate loop invariant info about the operands. Use a tuple
       // to hold the info for all operands.
-      std::tuple operand_infos(make_operand_info(drs)...);
+      auto operand_infos =
+          detail::tuple_transform(ranges, [tile_index](auto &&dr) {
+            auto tile = dr.grid()(tile_index, 0);
+            // mdspan for tile. This could be a submdspan, so we need the
+            // extents of the root to get the memory strides
+            return std::make_pair(tile.mdspan(), tile.root_mdspan().extents());
+          });
 
       auto tile1 = grid1(tile_index, 0).mdspan();
       if (mhp::use_sycl()) {
 #ifdef SYCL_LANGUAGE_VERSION
         auto do_point = [=](auto index) {
-          auto i = index[0];
-          auto j = index[1];
-          auto make_operands = [=](auto... infos) {
-            // Use mdspan for tile to calculate the address of the
-            // current element, and make an mdspan centered on it with
-            // strides from the root mdspan
-            return std::tuple(md::mdspan(std::to_address(&infos.first(i, j)),
-                                         infos.second)...);
-          };
-          op(std::apply(make_operands, operand_infos));
+          // Transform operand_infos into stencils
+          auto stencils =
+              detail::tuple_transform(operand_infos, [=](auto info) {
+                return md::mdspan(
+                    std::to_address(&info.first(index[0], index[1])),
+                    info.second);
+              });
+          op(stencils);
         };
         // TODO: Extend sycl_utils.hpp to handle ranges > 1D. It uses
         // ndrange and handles > 32 bits.
@@ -69,15 +71,15 @@ void stencil_for_each(auto op, is_mdspan_view auto &&...drs) {
       } else {
         // Given an index, invoke op on a tuple of stencils
         auto invoke_index = [=](auto index) {
-          // We have a tuple of infos and a index, invoke op on a
-          // tuple of stencils
-          auto invoke_op = [=](auto... infos) {
-            op(std::tuple(md::mdspan(std::to_address(&infos.first(index)),
-                                     infos.second)...));
-          };
-          std::apply(invoke_op, operand_infos);
+          // Transform operand_infos into stencils
+          auto stencils =
+              detail::tuple_transform(operand_infos, [=](auto info) {
+                return md::mdspan(std::to_address(&info.first(index)),
+                                  info.second);
+              });
+          op(stencils);
         };
-        dr::__detail::mdspan_foreach<tile1.rank(), decltype(invoke_index)>(
+        detail::mdspan_foreach<tile1.rank(), decltype(invoke_index)>(
             tile1.extents(), invoke_index);
       }
     }
@@ -88,7 +90,8 @@ void stencil_for_each(auto op, is_mdspan_view auto &&...drs) {
 
 /// Collective for_each on distributed range
 template <typename... Ts> void for_each(auto op, is_mdspan_view auto &&...drs) {
-  auto &&dr1 = std::get<0>(std::tie(drs...));
+  auto ranges = std::tie(drs...);
+  auto &&dr1 = std::get<0>(ranges);
   if (rng::empty(dr1)) {
     return;
   }
@@ -100,18 +103,20 @@ template <typename... Ts> void for_each(auto op, is_mdspan_view auto &&...drs) {
   for (std::size_t tile_index = 0; tile_index < grid1.extent(0); tile_index++) {
     // If local
     if (tile_index == default_comm().rank()) {
-      auto make_operand_mdspans = [=](auto &&dr) {
-        auto tile = dr.grid()(tile_index, 0);
-        return tile.mdspan();
-      };
-      // Calculate loop invariant info about the operands. Use a tuple
-      // to hold the info for all operands.
-      std::tuple operand_mdspans(make_operand_mdspans(drs)...);
+      // make a tuple of mdspans
+      auto operand_mdspans =
+          detail::tuple_transform(ranges, [tile_index](auto &&dr) {
+            auto tile = dr.grid()(tile_index, 0);
+            return tile.mdspan();
+          });
 
       auto tile1 = grid1(tile_index, 0).mdspan();
       if (mhp::use_sycl()) {
 #ifdef SYCL_LANGUAGE_VERSION
-        auto do_point = [=](auto index) {
+        // TODO: Cannot use tuple_transform because it appears to capture a
+        // value and not a reference. Some subtlety with parallel_for
+        // lambda capture?
+        auto invoke_index = [=](auto index) {
           auto i = index[0];
           auto j = index[1];
           auto make_operands = [=](auto... mdspans) {
@@ -119,26 +124,26 @@ template <typename... Ts> void for_each(auto op, is_mdspan_view auto &&...drs) {
           };
           op(std::apply(make_operands, operand_mdspans));
         };
+
         // TODO: Extend sycl_utils.hpp to handle ranges > 1D. It uses
         // ndrange and handles > 32 bits.
         dr::mhp::sycl_queue()
             .parallel_for(sycl::range(tile1.extent(0), tile1.extent(1)),
-                          do_point)
+                          invoke_index)
             .wait();
 #else
         assert(false);
 #endif
       } else {
-        // Given an index, invoke op on a tuple of references to mdspan element
+        // invoke op on a tuple of references created by using the mdspan's and
+        // index
         auto invoke_index = [=](auto index) {
-          // We have a tuple of mdspans and a index, invoke op on a
-          // tuple of references to mdspan elements
-          auto invoke_op = [=](auto... mdspans) {
-            op(std::tie(mdspans(index)...));
-          };
-          std::apply(invoke_op, operand_mdspans);
+          // Transform operand_infos into stencils
+          auto references = detail::tuple_transform(
+              operand_mdspans, [index](auto mdspan) { return mdspan(index); });
+          op(references);
         };
-        dr::__detail::mdspan_foreach<tile1.rank(), decltype(invoke_index)>(
+        detail::mdspan_foreach<tile1.rank(), decltype(invoke_index)>(
             tile1.extents(), invoke_index);
       }
     }

--- a/test/gtest/mhp/mdstar.cpp
+++ b/test/gtest/mhp/mdstar.cpp
@@ -309,7 +309,7 @@ TEST_F(MdForeach, 2ops) {
   xhp::iota(a, 100);
   xhp::iota(b, 200);
   auto copy_op = [](auto v) {
-    auto [in, out] = v;
+    auto &[in, out] = v;
     out = in;
   };
 
@@ -331,7 +331,9 @@ TEST_F(MdForeach, 3ops) {
   };
 
   xhp::for_each(copy_op, a, b, c);
-  EXPECT_EQ(a.mdspan()(2, 2) + b.mdspan()(2, 2), c.mdspan()(2, 2));
+  EXPECT_EQ(a.mdspan()(2, 2) + b.mdspan()(2, 2), c.mdspan()(2, 2))
+      << fmt::format("A:\n{}\nB:\n{}\nC:\n{}", a.mdspan(), b.mdspan(),
+                     c.mdspan());
 }
 
 using MdStencilForeach = Mdspan;
@@ -357,7 +359,7 @@ TEST_F(MdStencilForeach, 3ops) {
   xhp::distributed_mdarray<T, 2> c(extents2d);
   xhp::iota(a, 100);
   xhp::iota(b, 200);
-  xhp::iota(c, 200);
+  xhp::iota(c, 300);
   auto copy_op = [](auto v) {
     auto [in1, in2, out] = v;
     out(0, 0) = in1(0, 0) + in2(0, 0);


### PR DESCRIPTION
add tuple_foreach and tuple_transform to simplify md_foreach code. Gets rid of some tuple packing/unpacking and parameter pack folds.