### PR TITLE
Wave equation example uses mdarray

### DIFF
--- a/examples/mhp/CMakeLists.txt
+++ b/examples/mhp/CMakeLists.txt
@@ -41,6 +41,7 @@ add_mpi_test(stencil-2d-matrix-rows stencil-2d-matrix-rows 2)
 add_executable(wave_equation wave_equation.cpp)
 target_link_libraries(wave_equation cxxopts DR::mpi)
 add_mpi_test(wave_equation wave_equation 1)
+add_mpi_test(wave_equation_fused wave_equation 1 -f)
 
 if(OpenMP_FOUND)
   add_executable(vector-add-ref vector-add-ref.cpp)

--- a/examples/mhp/CMakeLists.txt
+++ b/examples/mhp/CMakeLists.txt
@@ -40,7 +40,7 @@ add_mpi_test(stencil-2d-matrix-rows stencil-2d-matrix-rows 2)
 
 add_executable(wave_equation wave_equation.cpp)
 target_link_libraries(wave_equation cxxopts DR::mpi)
-add_mpi_test(wave_equation wave_equation 4)
+add_mpi_test(wave_equation wave_equation 1)
 
 if(OpenMP_FOUND)
   add_executable(vector-add-ref vector-add-ref.cpp)

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -14,7 +14,8 @@ add_executable(
   ../common/subrange.cpp ../common/take.cpp ../common/transform.cpp
   ../common/transform_view.cpp ../common/zip.cpp ../common/zip_local.cpp
   alignment.cpp copy.cpp distributed_vector.cpp distributed_dense_matrix.cpp
-  halo.cpp mdstar.cpp reduce.cpp stencil.cpp segments.cpp slide_view.cpp)
+  halo.cpp mdstar.cpp reduce.cpp stencil.cpp segments.cpp slide_view.cpp
+  wave_kernel.cpp)
 
 add_executable(mhp-tests-3 mhp-tests.cpp halo-3.cpp slide_view-3.cpp
                            distributed_dense_matrix3.cpp)

--- a/test/gtest/mhp/wave_kernel.cpp
+++ b/test/gtest/mhp/wave_kernel.cpp
@@ -16,7 +16,7 @@ bool equal(MDA &a, std::vector<T> expected) {
   std::size_t k = 0;
   for (std::size_t i = 0; i < a.mdspan().extent(0); i++) {
     for (std::size_t j = 0; j < a.mdspan().extent(1); j++) {
-      result *= a.mdspan()(i, j) == expected[k];
+      result = result && a.mdspan()(i, j) == expected[k];
       k++;
     }
   }

--- a/test/gtest/mhp/wave_kernel.cpp
+++ b/test/gtest/mhp/wave_kernel.cpp
@@ -11,13 +11,12 @@ const int nx = 3, ny = 3;
 const std::size_t halo_radius = 1;
 auto dist = dr::mhp::distribution().halo(halo_radius);
 
-bool equal(MDA &a, std::initializer_list<T> expected) {
+bool equal(MDA &a, std::vector<T> expected) {
   bool result = true;
-  std::vector<T> v(expected);
   std::size_t k = 0;
   for (std::size_t i = 0; i < a.mdspan().extent(0); i++) {
     for (std::size_t j = 0; j < a.mdspan().extent(1); j++) {
-      result *= a.mdspan()(i, j) == v[k];
+      result *= a.mdspan()(i, j) == expected[k];
       k++;
     }
   }
@@ -61,25 +60,50 @@ MDA generate_v() {
 }
 
 TEST(MhpTests, WaveKernelCreateE) {
+  if (comm_size > 1)
+    return;
   MDA a = generate_e();
-  EXPECT_TRUE(equal(a, {0, 0, 0, 11, 12, 13, 12, 13, 14, 13, 14, 15}))
+  // first row is unused (all arrays must have the same number of rows)
+  // clang-format off
+  EXPECT_TRUE(equal(a, { 0,  0,  0,
+                        11, 12, 13,
+                        12, 13, 14,
+                        13, 14, 15}))
       << fmt::format("E:\n{}\n", a);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelCreateU) {
+  if (comm_size > 1)
+    return;
   MDA a = generate_u();
-  EXPECT_TRUE(equal(a, {10, 11, 12, 11, 12, 13, 12, 13, 14, 13, 14, 15}))
+  // clang-format off
+  EXPECT_TRUE(equal(a, {10, 11, 12,
+                        11, 12, 13,
+                        12, 13, 14,
+                        13, 14, 15}))
       << fmt::format("U:\n{}\n", a);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelCreateV) {
+  if (comm_size > 1)
+    return;
   MDA a = generate_v();
+  // first row is unused (all arrays must have the same number of rows)
+  // clang-format off
   EXPECT_TRUE(
-      equal(a, {0, 0, 0, 0, 11, 12, 13, 14, 12, 13, 14, 15, 13, 14, 15, 16}))
+      equal(a, { 0,  0,  0,  0,
+                11, 12, 13, 14,
+                12, 13, 14, 15,
+                13, 14, 15, 16}))
       << fmt::format("V:\n{}\n", a);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelDeDx) {
+  if (comm_size > 1)
+    return;
   MDA e = generate_e();
   MDA dedx({nx + 1, ny}, dist);
   dr::mhp::fill(dedx, 0.0);
@@ -101,11 +125,18 @@ TEST(MhpTests, WaveKernelDeDx) {
   dr::mhp::stencil_for_each(rhs_dedx, e_view, dedx_view);
 
   // first/last rows are boundary data, only interior values are computed
-  EXPECT_TRUE(equal(dedx, {0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0}))
+  // clang-format off
+  EXPECT_TRUE(equal(dedx, {0, 0, 0,
+                           1, 1, 1,
+                           1, 1, 1,
+                           0, 0, 0}))
       << fmt::format("dedx:\n{}\n", dedx);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelDeDy) {
+  if (comm_size > 1)
+    return;
   MDA e = generate_e();
   MDA dedy({nx + 1, ny + 1}, dist);
   dr::mhp::fill(dedy, 0.0);
@@ -123,13 +154,20 @@ TEST(MhpTests, WaveKernelDeDy) {
   auto dedy_view = dr::mhp::views::submdspan(dedy.view(), start, end);
   dr::mhp::stencil_for_each(rhs_dedy, e_view, dedy_view);
 
-  // first row is unused (number of rows must be the same for all arrays)
+  // first row is unused (all arrays must have the same number of rows)
   // first/last cols are boundary data, only interior values are computed
-  EXPECT_TRUE(equal(dedy, {0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0}))
+  // clang-format off
+  EXPECT_TRUE(equal(dedy, {0, 0, 0, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0,
+                           0, 1, 1, 0}))
       << fmt::format("dedy:\n{}\n", dedy);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelDuDx) {
+  if (comm_size > 1)
+    return;
   MDA u = generate_u();
   MDA dudx({nx + 1, ny}, dist);
   dr::mhp::fill(dudx, 0.0);
@@ -146,12 +184,19 @@ TEST(MhpTests, WaveKernelDuDx) {
   auto dudx_view = dr::mhp::views::submdspan(dudx.view(), start, end);
   dr::mhp::stencil_for_each(rhs_dudx, u_view, dudx_view);
 
-  // first row is unused (number of rows must be the same for all arrays)
-  EXPECT_TRUE(equal(dudx, {0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+  // first row is unused (all arrays must have the same number of rows)
+  // clang-format off
+  EXPECT_TRUE(equal(dudx, {0, 0, 0,
+                           1, 1, 1,
+                           1, 1, 1,
+                           1, 1, 1}))
       << fmt::format("dudx:\n{}\n", dudx);
+  // clang-format on
 }
 
 TEST(MhpTests, WaveKernelDvDy) {
+  if (comm_size > 1)
+    return;
   MDA v = generate_v();
   MDA dvdy({nx + 1, ny}, dist);
   dr::mhp::fill(dvdy, 0.0);
@@ -168,7 +213,12 @@ TEST(MhpTests, WaveKernelDvDy) {
   auto dvdy_view = dr::mhp::views::submdspan(dvdy.view(), start, end);
   dr::mhp::stencil_for_each(rhs_dvdy, v_view, dvdy_view);
 
-  // first row is unused (number of rows must be the same for all arrays)
-  EXPECT_TRUE(equal(dvdy, {0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+  // first row is unused (all arrays must have the same number of rows)
+  // clang-format off
+  EXPECT_TRUE(equal(dvdy, {0, 0, 0,
+                           1, 1, 1,
+                           1, 1, 1,
+                           1, 1, 1}))
       << fmt::format("dvdy:\n{}\n", dvdy);
+  // clang-format on
 }

--- a/test/gtest/mhp/wave_kernel.cpp
+++ b/test/gtest/mhp/wave_kernel.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xhp-tests.hpp"
+#include <dr/mhp/views/sliding.hpp>
+
+using T = double;
+using MDA = dr::mhp::distributed_mdarray<T, 2>;
+const int nx = 3, ny = 3;
+const std::size_t halo_radius = 1;
+auto dist = dr::mhp::distribution().halo(halo_radius);
+
+bool equal(MDA &a, std::initializer_list<T> expected) {
+  bool result = true;
+  std::vector<T> v(expected);
+  std::size_t k = 0;
+  for (std::size_t i = 0; i < a.mdspan().extent(0); i++) {
+    for (std::size_t j = 0; j < a.mdspan().extent(1); j++) {
+      result *= a.mdspan()(i, j) == v[k];
+      k++;
+    }
+  }
+  return result;
+}
+
+MDA generate_e() {
+  MDA a({nx + 1, ny}, dist);
+  dr::mhp::fill(a, 0.0);
+  for (size_t i = 1; i < a.mdspan().extent(0); i++) {
+    for (size_t j = 0; j < a.mdspan().extent(1); j++) {
+      a.mdspan()(i, j) = 10 + i + j;
+    }
+  }
+  dr::mhp::halo(a).exchange();
+  return a;
+}
+
+MDA generate_u() {
+  MDA a({nx + 1, ny}, dist);
+  dr::mhp::fill(a, 0.0);
+  for (size_t i = 0; i < a.mdspan().extent(0); i++) {
+    for (size_t j = 0; j < a.mdspan().extent(1); j++) {
+      a.mdspan()(i, j) = 10 + i + j;
+    }
+  }
+  dr::mhp::halo(a).exchange();
+  return a;
+}
+
+MDA generate_v() {
+  MDA a({nx + 1, ny + 1}, dist);
+  dr::mhp::fill(a, 0.0);
+  for (size_t i = 1; i < a.mdspan().extent(0); i++) {
+    for (size_t j = 0; j < a.mdspan().extent(1); j++) {
+      a.mdspan()(i, j) = 10 + i + j;
+    }
+  }
+  dr::mhp::halo(a).exchange();
+  return a;
+}
+
+TEST(MhpTests, WaveKernelCreateE) {
+  MDA a = generate_e();
+  EXPECT_TRUE(equal(a, {0, 0, 0, 11, 12, 13, 12, 13, 14, 13, 14, 15}))
+      << fmt::format("E:\n{}\n", a);
+}
+
+TEST(MhpTests, WaveKernelCreateU) {
+  MDA a = generate_u();
+  EXPECT_TRUE(equal(a, {10, 11, 12, 11, 12, 13, 12, 13, 14, 13, 14, 15}))
+      << fmt::format("U:\n{}\n", a);
+}
+
+TEST(MhpTests, WaveKernelCreateV) {
+  MDA a = generate_v();
+  EXPECT_TRUE(
+      equal(a, {0, 0, 0, 0, 11, 12, 13, 14, 12, 13, 14, 15, 13, 14, 15, 16}))
+      << fmt::format("V:\n{}\n", a);
+}
+
+TEST(MhpTests, WaveKernelDeDx) {
+  MDA e = generate_e();
+  MDA dedx({nx + 1, ny}, dist);
+  dr::mhp::fill(dedx, 0.0);
+
+  auto rhs_dedx = [](auto v) {
+    auto [in, out] = v;
+    out(0, 0) = in(1, 0) - in(0, 0);
+  };
+  std::array<std::size_t, 2> start{1, 0};
+  std::array<std::size_t, 2> end{
+      static_cast<std::size_t>(e.mdspan().extent(0) - 1),
+      static_cast<std::size_t>(e.mdspan().extent(1))};
+  // FIXME this should work; currently extents require std::size_t type
+  // auto e_view = dr::mhp::views::submdspan(e.view(), {1, 0},
+  //                                         {e.mdspan().extent(0)-1,
+  //                                          e.mdspan().extent(1)});
+  auto e_view = dr::mhp::views::submdspan(e.view(), start, end);
+  auto dedx_view = dr::mhp::views::submdspan(dedx.view(), start, end);
+  dr::mhp::stencil_for_each(rhs_dedx, e_view, dedx_view);
+
+  // first/last rows are boundary data, only interior values are computed
+  EXPECT_TRUE(equal(dedx, {0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0}))
+      << fmt::format("dedx:\n{}\n", dedx);
+}
+
+TEST(MhpTests, WaveKernelDeDy) {
+  MDA e = generate_e();
+  MDA dedy({nx + 1, ny + 1}, dist);
+  dr::mhp::fill(dedy, 0.0);
+
+  auto rhs_dedy = [](auto v) {
+    auto [in, out] = v;
+    out(0, 0) = in(0, 0) - in(0, -1);
+  };
+
+  std::array<std::size_t, 2> start{0, 1};
+  std::array<std::size_t, 2> end{
+      static_cast<std::size_t>(e.mdspan().extent(0)),
+      static_cast<std::size_t>(e.mdspan().extent(1))};
+  auto e_view = dr::mhp::views::submdspan(e.view(), start, end);
+  auto dedy_view = dr::mhp::views::submdspan(dedy.view(), start, end);
+  dr::mhp::stencil_for_each(rhs_dedy, e_view, dedy_view);
+
+  // first row is unused (number of rows must be the same for all arrays)
+  // first/last cols are boundary data, only interior values are computed
+  EXPECT_TRUE(equal(dedy, {0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0}))
+      << fmt::format("dedy:\n{}\n", dedy);
+}
+
+TEST(MhpTests, WaveKernelDuDx) {
+  MDA u = generate_u();
+  MDA dudx({nx + 1, ny}, dist);
+  dr::mhp::fill(dudx, 0.0);
+
+  auto rhs_dudx = [](auto v) {
+    auto [in, out] = v;
+    out(0, 0) = in(0, 0) - in(-1, 0);
+  };
+  std::array<std::size_t, 2> start{1, 0};
+  std::array<std::size_t, 2> end{
+      static_cast<std::size_t>(u.mdspan().extent(0)),
+      static_cast<std::size_t>(u.mdspan().extent(1))};
+  auto u_view = dr::mhp::views::submdspan(u.view(), start, end);
+  auto dudx_view = dr::mhp::views::submdspan(dudx.view(), start, end);
+  dr::mhp::stencil_for_each(rhs_dudx, u_view, dudx_view);
+
+  // first row is unused (number of rows must be the same for all arrays)
+  EXPECT_TRUE(equal(dudx, {0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+      << fmt::format("dudx:\n{}\n", dudx);
+}
+
+TEST(MhpTests, WaveKernelDvDy) {
+  MDA v = generate_v();
+  MDA dvdy({nx + 1, ny}, dist);
+  dr::mhp::fill(dvdy, 0.0);
+
+  auto rhs_dvdy = [](auto v) {
+    auto [in, out] = v;
+    out(0, 0) = in(0, 1) - in(0, 0);
+  };
+  std::array<std::size_t, 2> start{1, 0};
+  std::array<std::size_t, 2> end{
+      static_cast<std::size_t>(v.mdspan().extent(0)),
+      static_cast<std::size_t>(v.mdspan().extent(1) - 1)};
+  auto v_view = dr::mhp::views::submdspan(v.view(), start, end);
+  auto dvdy_view = dr::mhp::views::submdspan(dvdy.view(), start, end);
+  dr::mhp::stencil_for_each(rhs_dvdy, v_view, dvdy_view);
+
+  // first row is unused (number of rows must be the same for all arrays)
+  EXPECT_TRUE(equal(dvdy, {0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+      << fmt::format("dvdy:\n{}\n", dvdy);
+}


### PR DESCRIPTION
- [x] wave equation example uses `dr::mhp::distributed_mdarray` object
- [x] adds wave equation kernel unit tests