### PR TITLE
selective build fix

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   devcloud:
     runs-on: devcloud
+    # if it does not finish in 20 minutes, it is likely hung
+    timeout-minutes: 20
     name: "Devcloud Benchmarking"
     env:
       CXX: icpx

--- a/scripts/devcloud-build.sh
+++ b/scripts/devcloud-build.sh
@@ -10,7 +10,5 @@ source /opt/intel/oneapi/setvars.sh
 # devcloud requires --launcher=fork for mpi
 cmake -B build -DENABLE_SYCL=on -DENABLE_MPIFORK=on
 
-cmake --build build -j
-
-# selective build below is broken
-#cmake --build build -j ${1:+"--target "$@}
+BUILD_TARGETS=("$@")
+cmake --build build -j "${BUILD_TARGETS[@]/#/-t }"


### PR DESCRIPTION
works in daily.yml
daily lasts 6 minutes
see: https://github.com/oneapi-src/distributed-ranges/actions/runs/5719036161/job/15496111873