### PR TITLE
refactor targets for drbench

### DIFF
--- a/benchmarks/gbench/CMakeLists.txt
+++ b/benchmarks/gbench/CMakeLists.txt
@@ -20,11 +20,20 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   if(ENABLE_SYCL)
     add_subdirectory(shp)
 
+    set(COMMON_PREFIX
+        dr-bench --analysis_id daily analyze --no-plot -s 1000000 -f Stream_ -f
+        Black_Scholes -f DotProduct_)
+    message(STATUS "Common prefix ${COMMON_PREFIX}")
     add_custom_target(bench DEPENDS bench-results)
     add_custom_command(
       OUTPUT bench-results
-      COMMAND dr-bench analyze -n 1 -n 2 -n 3 -n 4 -s 1000000 -m mhp_gpu -m
-              mhp_cpu -m shp -f Stream_ -f Black_Scholes -f DotProduct_
+      # devcloud: 4 GPUs, 2 sockets, 112 cores
+      COMMAND ${COMMON_PREFIX} -n 1 -n 2 -n 3 -n 4 -t mhp_sycl_gpu -t
+              shp_sycl_gpu
+      COMMAND ${COMMON_PREFIX} -n 1 -n 2 -m mhp_sycl_cpu -m shp_sycl_cpu
+      COMMAND ${COMMON_PREFIX} -n 1 -n 2 -n 4 -n 8 -n 56 -n 112 -t
+              mhp_direct_cpu
+      COMMAND dr-bench --analysis_id daily plot
       DEPENDS mhp-bench shp-bench)
   endif()
 endif()

--- a/src-python/drbench/drbench/common.py
+++ b/src-python/drbench/drbench/common.py
@@ -2,10 +2,32 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from collections import namedtuple
+from enum import Enum
+
 
 class Config:
-    analysis_id = ''
+    analysis_id = ""
 
 
 def analysis_file_prefix(analysis_id: str):
-    return f'dr-bench-{analysis_id}'
+    return f"dr-bench-{analysis_id}"
+
+
+Model = Enum("Model", ["SHP", "MHP"])
+Runtime = Enum("Runtime", ["SYCL", "DIRECT"])
+Device = Enum("Device", ["GPU", "CPU"])
+
+
+class Target(namedtuple("Target", "model runtime device")):
+    def __repr__(self):
+        return f"{self.model.name}_{self.runtime.name}_{self.device.name}"
+
+
+targets = {
+    "mhp_direct_cpu": Target(Model.MHP, Runtime.DIRECT, Device.CPU),
+    "mhp_sycl_cpu": Target(Model.MHP, Runtime.SYCL, Device.CPU),
+    "mhp_sycl_gpu": Target(Model.MHP, Runtime.SYCL, Device.GPU),
+    "shp_sycl_cpu": Target(Model.SHP, Runtime.SYCL, Device.CPU),
+    "shp_sycl_gpu": Target(Model.SHP, Runtime.SYCL, Device.GPU),
+}

--- a/src-python/drbench/drbench/drbench.py
+++ b/src-python/drbench/drbench/drbench.py
@@ -13,10 +13,10 @@ from drbench import common, plotter, runner
 # common arguments
 @click.group()
 @click.option(
-    '--analysis_id',
+    "--analysis_id",
     type=str,
-    default='',
-    help='id to use in output files, use time based if missing',
+    default="",
+    help="id to use in output files, use time based if missing",
 )
 @click.pass_context
 def cli(ctx, analysis_id: str):
@@ -25,7 +25,7 @@ def cli(ctx, analysis_id: str):
         ctx.obj.analysis_id = analysis_id
     else:
         ctx.obj.analysis_id = datetime.datetime.now().strftime(
-            '%Y-%m-%d_%H_%M_%S'
+            "%Y-%m-%d_%H_%M_%S"
         )
 
 
@@ -40,83 +40,75 @@ def plot(ctx):
     __plot_impl(ctx)
 
 
-Choice = click.Choice(['mhp_cpu', 'mhp_gpu', 'mhp_nosycl', 'shp'])
+Choice = click.Choice(common.targets.keys())
 
 
-def choice_to_mode(c):
-    if c == 'mhp_cpu':
-        return runner.AnalysisMode.MHP_CPU
-    if c == 'mhp_gpu':
-        return runner.AnalysisMode.MHP_GPU
-    if c == 'mhp_nosycl':
-        return runner.AnalysisMode.MHP_NOSYCL
-    if c == 'shp':
-        return runner.AnalysisMode.SHP
-    assert False
+def choice_to_target(c):
+    return common.targets[c]
 
 
 @cli.command()
 @click.option(
-    '--no-plot',
-    'plot',
+    "--no-plot",
+    "plot",
     default=True,
     is_flag=True,
     help="don't create plots, just json files",
 )
 @click.option(
-    '-m',
-    '--mode',
+    "-t",
+    "--target",
     type=Choice,
     multiple=True,
-    default=['mhp_cpu'],
-    help='modes of benchmarking to run',
+    default=["mhp_direct_cpu"],
+    help="Target to execute benchmark",
 )
 @click.option(
-    '-s',
-    '--vec-size',
+    "-s",
+    "--vec-size",
     type=int,
     multiple=True,
     default=[1000000],
-    help='Size of a vector',
+    help="Size of a vector",
 )
 @click.option(
-    '-n',
-    '--nprocs',
+    "-n",
+    "--nprocs",
     type=int,
     multiple=True,
     default=[1],
-    help='Number of processes',
+    help="Number of processes",
 )
 @click.option(
-    '--no-fork',
-    'fork',
+    "--no-fork",
+    "fork",
     default=True,
     is_flag=True,
     help="don't use -launcher=fork with mpi",
 )
-@click.option('-r', '--reps', default=100, type=int, help='Number of reps')
+@click.option("-r", "--reps", default=100, type=int, help="Number of reps")
 @click.option(
-    '-f',
-    '--filter',
+    "-f",
+    "--filter",
     type=str,
     multiple=True,
-    default=['Stream_'],
-    help='A filter used for a benchmark',
+    default=["Stream_"],
+    help="A filter used for a benchmark",
 )
 @click.option(
-    '--mhp-bench',
-    default='mhp/mhp-bench',
+    "--mhp-bench",
+    default="mhp/mhp-bench",
     type=str,
-    help='MHP benchmark program',
+    help="MHP benchmark program",
 )
 @click.option(
-    '--shp-bench',
-    default='shp/shp-bench',
+    "--shp-bench",
+    default="shp/shp-bench",
     type=str,
-    help='SHP benchmark program',
+    help="SHP benchmark program",
 )
 @click.option(
-    '-d', '--dry-run', is_flag=True, help='Emits commands but does not execute'
+    "-d", "--dry-run", is_flag=True, help="Emits commands but does not execute"
 )
 @click.pass_context
 def analyze(
@@ -139,7 +131,7 @@ def analyze(
     r = runner.Runner(
         runner.AnalysisConfig(
             ctx.obj,
-            '\\|'.join(filter),
+            "\\|".join(filter),
             fork,
             reps,
             dry_run,
@@ -151,12 +143,12 @@ def analyze(
         for s in vec_size:
             for n in nprocs:
                 r.run_one_analysis(
-                    runner.AnalysisCase(choice_to_mode(m), s, n)
+                    runner.AnalysisCase(choice_to_target(m), s, n)
                 )
 
     if plot:
         __plot_impl(ctx)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     assert False  # not to be used this way, but by dr-bench executable

--- a/src-python/drbench/drbench/runner.py
+++ b/src-python/drbench/drbench/runner.py
@@ -5,18 +5,15 @@
 import glob
 import subprocess
 from collections import namedtuple
-from enum import Enum
 
 import click
 from drbench import common
+from drbench.common import Device, Model, Runtime
 
-AnalysisMode = Enum(
-    'AnalysisMode', ['MHP_CPU', 'MHP_GPU', 'MHP_NOSYCL', 'SHP']
-)
-AnalysisCase = namedtuple('AnalysisCase', 'mode size nprocs')
+AnalysisCase = namedtuple("AnalysisCase", "target size nprocs")
 AnalysisConfig = namedtuple(
-    'AnalysisConfig',
-    'common_config benchmark_filter fork reps dry_run mhp_bench shp_bench',
+    "AnalysisConfig",
+    "common_config benchmark_filter fork reps dry_run mhp_bench shp_bench",
 )
 
 
@@ -36,70 +33,69 @@ class Runner:
 
         i = 0
         while True:
-            p = f'{prefix}.{case.mode}.n{case.nprocs}.s{case.size}.i{i}i'
-            if not glob.glob(f'{p}*'):
+            p = f"{prefix}.{case.target}.n{case.nprocs}.s{case.size}.i{i}i"
+            if not glob.glob(f"{p}*"):
                 rank = ".rankNNN" if add_nnn else ""
-                return f'{p}{rank}.json'
+                return f"{p}{rank}.json"
             i = i + 1
 
-    def __run_mhp_analysis(self, params, nprocs, mode):
-        if mode == AnalysisMode.MHP_CPU:
-            env = 'ONEAPI_DEVICE_SELECTOR=opencl:cpu'
-            params.append('--sycl')
-        elif mode == AnalysisMode.MHP_GPU:
-            env = (
-                'ONEAPI_DEVICE_SELECTOR=\'level_zero:gpu;ext_oneapi_cuda:gpu\''
-            )
-            params.append('--sycl')
-        elif mode == AnalysisMode.MHP_NOSYCL:
-            env = (
-                'I_MPI_PIN_DOMAIN=core '
-                'I_MPI_PIN_ORDER=compact '
-                'I_MPI_PIN_CELL=unit'
-            )
+    def __run_mhp_analysis(self, params, nprocs, target):
+        if target.runtime == Runtime.SYCL:
+            params.append("--sycl")
+            if target.device == Device.CPUModel:
+                env = "ONEAPI_DEVICE_SELECTOR=opencl:cpu"
+            else:
+                env = (
+                    "ONEAPI_DEVICE_SELECTOR="
+                    "'level_zero:gpu;ext_oneapi_cuda:gpu'"
+                )
         else:
-            assert False
+            env = (
+                "I_MPI_PIN_DOMAIN=core "
+                "I_MPI_PIN_ORDER=compact "
+                "I_MPI_PIN_CELL=unit"
+            )
 
         mpirun_params = []
-        mpirun_params.append(f'-n {str(nprocs)}')
+        mpirun_params.append(f"-n {str(nprocs)}")
         if self.analysis_config.fork:
-            mpirun_params.append('-launcher=fork')
+            mpirun_params.append("-launcher=fork")
 
         self.__execute(
             env
-            + ' mpirun '
+            + " mpirun "
             + " ".join(mpirun_params)
-            + ' '
+            + " "
             + self.analysis_config.mhp_bench
-            + ' '
+            + " "
             + " ".join(params)
         )
 
     def __run_shp_analysis(self, params, nprocs):
-        env = 'KMP_AFFINITY=compact'
-        params.append(f'--num-devices {nprocs}')
+        env = "KMP_AFFINITY=compact"
+        params.append(f"--num-devices {nprocs}")
         self.__execute(
             f'{env} {self.analysis_config.shp_bench} {" ".join(params)}'
         )
 
     def run_one_analysis(self, analysis_case: AnalysisCase):
         params = []
-        params.append(f'--vector-size {str(analysis_case.size)}')
-        params.append(f'--reps {str(self.analysis_config.reps)}')
-        params.append('--benchmark_out_format=json')
+        params.append(f"--vector-size {str(analysis_case.size)}")
+        params.append(f"--reps {str(self.analysis_config.reps)}")
+        params.append("--benchmark_out_format=json")
         outfname = self.__out_filename(
-            analysis_case, analysis_case.mode != AnalysisMode.SHP
+            analysis_case, analysis_case.target.model != Model.SHP
         )
-        params.append(f'--benchmark_out={outfname}')
+        params.append(f"--benchmark_out={outfname}")
 
         if self.analysis_config.benchmark_filter:
             params.append(
-                f'--benchmark_filter={self.analysis_config.benchmark_filter}'
+                f"--benchmark_filter={self.analysis_config.benchmark_filter}"
             )
 
-        if analysis_case.mode == AnalysisMode.SHP:
+        if analysis_case.target.model == Model.SHP:
             self.__run_shp_analysis(params, analysis_case.nprocs)
         else:
             self.__run_mhp_analysis(
-                params, analysis_case.nprocs, analysis_case.mode
+                params, analysis_case.nprocs, analysis_case.target
             )


### PR DESCRIPTION
Separate GPU and CPU SYCL runs so we can adjust the number of ranks.
Change Mode to Target. It is a triple:
* Model: SHP/MHP
* Runtime: Sycl/Direct
* Device: CPU/GPU

For some reason, black formatter changed single quotes to double quotes in this commit.