### PR TITLE
replace mpifork flags with env variable

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       CXX: icpx
       CTEST_OUTPUT_ON_FAILURE: 1
+      MPIEXEC_EXTRA_FLAGS: --launcher=fork
     steps:
     - uses: actions/checkout@v3
     - name: Python setup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,6 +101,7 @@ jobs:
     timeout-minutes: 20
     env:
       CXX: icpx
+      MPIEXEC_EXTRA_FLAGS: --launcher=fork
     steps:
     - uses: actions/checkout@v3
     - name: Python setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   option(ENABLE_SYCL "Build sycl shp examples" OFF)
   option(ENABLE_CUDA "Build for cuda" OFF)
   option(ENABLE_FORMAT "Build with format library" ON)
-  option(ENABLE_MPIFORK "Use MPI fork launcher" OFF)
   option(GCC_TOOLCHAIN, "GCC toolchain to be used by clang-based compilers" OFF)
 
   #
@@ -28,10 +27,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   #
   set(CMAKE_CXX_EXTENSIONS OFF)
   set(CMAKE_CXX_STANDARD 20)
-
-  if(ENABLE_MPIFORK)
-    set(MPIEXEC_LAUNCHFLAGS "-launcher=fork")
-  endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-fconcepts-diagnostics-depth=10)
@@ -140,7 +135,7 @@ function(add_mpi_test test_name name processes)
     NAME ${test_name}
     COMMAND
       ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${processes}
-      ${MPIEXEC_PREFLAGS} ${MPIEXEC_LAUNCHFLAGS} ./${name} ${ARGN}
+      ${MPIEXEC_PREFLAGS} $ENV{MPIEXEC_EXTRA_FLAGS} ./${name} ${ARGN}
       COMMAND_EXPAND_LISTS)
 endfunction()
 

--- a/benchmarks/gbench/CMakeLists.txt
+++ b/benchmarks/gbench/CMakeLists.txt
@@ -22,9 +22,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
     set(COMMON_PREFIX dr-bench run --vec-size 1000000000)
     set(DR_FILTERS
-        --filter Stream_ --filter Black_Scholes --filter Inclusive_Scan_DR
-        --filter Reduce_DR)
-    set(SERIAL_FILTERS --filter '.*_DPL' --filter '.*_Serial')
+        --filter ^Stream_ --filter ^Black_Scholes --filter ^Inclusive_Scan_DR
+        --filter ^Reduce_DR)
+    set(SERIAL_FILTERS --filter '.*_DPL')
 
     add_custom_target(devcloud-bench DEPENDS devcloud-bench-results)
     add_custom_command(

--- a/src-python/drbench/drbench/drbench.py
+++ b/src-python/drbench/drbench/drbench.py
@@ -72,13 +72,6 @@ def choice_to_target(c):
     default=[1],
     help="Number of processes",
 )
-@click.option(
-    "--no-fork",
-    "fork",
-    default=True,
-    is_flag=True,
-    help="don't use -launcher=fork with mpi",
-)
 @click.option("--reps", default=100, type=int, help="Number of reps")
 @click.option(
     "-f",
@@ -111,7 +104,6 @@ def run(
     target,
     vec_size,
     ranks,
-    fork,
     reps,
     filter,
     mhp_bench,
@@ -130,7 +122,6 @@ def run(
         runner.AnalysisConfig(
             prefix,
             "\\|".join(filter),
-            fork,
             reps,
             dry_run,
             mhp_bench,

--- a/src-python/drbench/drbench/runner.py
+++ b/src-python/drbench/drbench/runner.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
 import subprocess
 import uuid
 from collections import namedtuple
@@ -12,7 +13,7 @@ from drbench.common import Device, Model, Runtime
 AnalysisCase = namedtuple("AnalysisCase", "target size ranks")
 AnalysisConfig = namedtuple(
     "AnalysisConfig",
-    "prefix benchmark_filter fork reps dry_run mhp_bench shp_bench",
+    "prefix benchmark_filter reps dry_run mhp_bench shp_bench",
 )
 
 
@@ -44,8 +45,9 @@ class Runner:
 
         mpirun_params = []
         mpirun_params.append(f"-n {str(ranks)}")
-        if self.analysis_config.fork:
-            mpirun_params.append("-launcher=fork")
+        extra = 'MPIEXEC_EXTRA_FLAGS'
+        if extra in os.environ:
+            mpirun_params.append(os.environ[extra])
 
         self.__execute(
             env


### PR DESCRIPTION
On devcloud, we need to add --launcher=fork to mpirun commands to workaround a problem in their configuration. We were using command line switches to add the flag, but it was getting complicated and it was easy to make a mistake. Use an env variable instead. The CI yaml set the variables in 1 place. You should also add this to your `.bashrc` on devcloud if you want to run directly.
```
# workaround for misconfigured SLURM/MPI on devcloud
export MPIEXEC_EXTRA_FLAGS=--launcher=fork
```

@lslusarczyk @lslusarczyk: FYI