### PR TITLE
workaround dpl divot by passing std::plus to inclusive_scan benchmarks

### DIFF
--- a/benchmarks/gbench/common/inclusive_scan.cpp
+++ b/benchmarks/gbench/common/inclusive_scan.cpp
@@ -14,7 +14,7 @@ static void Inclusive_Scan_DR(benchmark::State &state) {
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       stats.rep();
-      xhp::inclusive_scan(a, b);
+      xhp::inclusive_scan(a, b, std::plus<>{});
     }
   }
 }
@@ -33,7 +33,7 @@ static void Inclusive_Scan_DPL(benchmark::State &state) {
   for (auto _ : state) {
     for (std::size_t i = 0; i < default_repetitions; i++) {
       stats.rep();
-      std::inclusive_scan(policy, a, a + default_vector_size, b);
+      std::inclusive_scan(policy, a, a + default_vector_size, b, std::plus<>{});
     }
   }
   sycl::free(a, q);

--- a/benchmarks/gbench/mhp/CMakeLists.txt
+++ b/benchmarks/gbench/mhp/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(mhp-bench benchmark::benchmark cxxopts DR::mpi)
 
 # cmake-format: off
 add_executable(mhp-quick-bench mhp-bench.cpp
-  ../common/distributed_vector.cpp
+  ../common/inclusive_scan.cpp
   )
 # cmake-format: on
 target_compile_definitions(mhp-quick-bench PRIVATE BENCH_MHP)


### PR DESCRIPTION
Filed ticket: ONEDPL-867

@lslusarczyk @BenBrock 