### PR TITLE
bench: plot cores instead of sockets

### DIFF
--- a/benchmarks/gbench/CMakeLists.txt
+++ b/benchmarks/gbench/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_custom_command(
       OUTPUT aurora-bench-results
       COMMAND dr-bench clean
-      COMMAND dr-bench suite --vec-size 4000000000 --gpus 12
+      COMMAND dr-bench suite --gpus 12
       COMMAND dr-bench plot
       DEPENDS mhp-bench shp-bench)
 
@@ -40,8 +40,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_custom_command(
       OUTPUT aurora-bench-2-results
       COMMAND dr-bench clean --prefix aurora-2
-      COMMAND dr-bench suite --prefix aurora-2 --vec-size 4000000000 --nodes 2
-              --gpus 12
+      COMMAND dr-bench suite --prefix aurora-2 --nodes 2 --gpus 12
       COMMAND dr-bench plot --prefix aurora-2
       DEPENDS mhp-bench shp-bench)
 
@@ -49,8 +48,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     add_custom_command(
       OUTPUT aurora-bench-4-results
       COMMAND dr-bench clean --prefix aurora-4
-      COMMAND dr-bench suite --prefix aurora-4 --vec-size 4000000000 --nodes 4
-              --gpus 12
+      COMMAND dr-bench suite --prefix aurora-4 --nodes 4 --gpus 12
       COMMAND dr-bench plot --prefix aurora-4
       DEPENDS mhp-bench shp-bench)
 

--- a/src-python/drbench/drbench/plotter.py
+++ b/src-python/drbench/drbench/plotter.py
@@ -46,6 +46,9 @@ class Plotter:
                     r"Core\(s\) per socket:\s*(\d+)", ctx["lscpu"]
                 ).group(1)
             )
+            cpu_cores = (
+                ranks if runtime == "DIRECT" else ranks * cores_per_socket
+            )
             for b in benchs:
                 bname = b["name"].partition("/")[0]
                 bname, btarget = Plotter.__name_target(bname, target, device)
@@ -61,9 +64,7 @@ class Plotter:
                         "Benchmark": bname,
                         "Ranks": ranks,
                         "GPU Tiles": ranks,
-                        "CPU Sockets": ranks / cores_per_socket
-                        if runtime == "DIRECT" and device == "CPU"
-                        else ranks,
+                        "CPU Cores": cpu_cores,
                         "rtime": rtime,
                         Plotter.bandwidth_title: bw / 1e12,
                     }
@@ -126,7 +127,7 @@ class Plotter:
         self.__make_plot(
             "stream_strong_scaling_cpu",
             db_cpu,
-            x="CPU Sockets",
+            x="CPU Cores",
             y=Plotter.bandwidth_title,
             col="Benchmark",
             style="Target",
@@ -155,7 +156,7 @@ class Plotter:
         self.__make_plot(
             "algorithms_cpu",
             db_cpu,
-            x="CPU Sockets",
+            x="CPU Cores",
             y=Plotter.bandwidth_title,
             col="Benchmark",
             style="Target",


### PR DESCRIPTION
black scholes runs out of memory with 4B, so use 2B