### PR TITLE
change dot product to double to see if it caused failures

### DIFF
--- a/benchmarks/gbench/common/dot_product.cpp
+++ b/benchmarks/gbench/common/dot_product.cpp
@@ -11,7 +11,7 @@
 #include <oneapi/dpl/numeric>
 #endif
 
-using T = float;
+using T = double;
 
 static T init_val = 1;
 


### PR DESCRIPTION
Random failures started here: https://github.com/oneapi-src/distributed-ranges/commit/de36e3a81cfef3f051211a4581adf7ac2280cc50#diff-ccdf102c9f46e5c5584559c5fa0f6fe49eac8fea40c9bbf29ac520a1bd2e301d

It is always dot product. See if this triggered the problem.