### PR TITLE
Gemm mkl

### DIFF
--- a/benchmarks/gbench/shp/CMakeLists.txt
+++ b/benchmarks/gbench/shp/CMakeLists.txt
@@ -22,6 +22,6 @@ if(NOT ENABLE_CUDA)
 endif()
 
 target_compile_definitions(shp-bench PRIVATE BENCH_SHP)
-target_link_libraries(shp-bench benchmark::benchmark cxxopts DR::mpi)
+target_link_libraries(shp-bench benchmark::benchmark cxxopts DR::shp)
 
 add_test(NAME shp-bench COMMAND ./shp-bench --vector-size 20000)

--- a/benchmarks/gbench/shp/CMakeLists.txt
+++ b/benchmarks/gbench/shp/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_executable(
   shp-bench
   shp-bench.cpp
+  gemm.cpp
   ../common/sort.cpp
   ../common/distributed_vector.cpp
   ../common/dot_product.cpp

--- a/benchmarks/gbench/shp/gemm.cpp
+++ b/benchmarks/gbench/shp/gemm.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Intel Corporation
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "../common/dr_bench.hpp"
+
+using T = float;
+
+#include <oneapi/mkl.hpp>
+
+static void Gemm_DR(benchmark::State &state) {
+  auto q = get_queue();
+
+  std::size_t m = 32;
+  std::size_t n = 32;
+  std::size_t k = 32;
+
+  auto partitions = dr::shp::partition_matmul(m, n, k);
+  dr::shp::distributed_dense_matrix<T> a({m, k}, partitions[0]);
+  dr::shp::distributed_dense_matrix<T> b({k, n}, partitions[1]);
+  dr::shp::distributed_dense_matrix<T> result({m, n}, partitions[2]);
+
+  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T));
+  a[{2, 3}] = 12;
+  a[{5, 7}] = 42;
+  a[{8, 9}] = 37;
+
+  b[{2, 3}] = 12;
+  b[{5, 7}] = 42;
+  b[{8, 9}] = 37;
+
+  for (auto _ : state) {
+    stats.rep();
+    dr::shp::gemm_inplace(a, b, result);
+  }
+}
+
+DR_BENCHMARK(Gemm_DR);

--- a/benchmarks/gbench/shp/gemm.cpp
+++ b/benchmarks/gbench/shp/gemm.cpp
@@ -6,7 +6,15 @@
 
 using T = float;
 
+#include <dr/shp.hpp>
+
 #include <oneapi/mkl.hpp>
+
+template <rng::forward_range X> void fill_random(X &&x) {
+  for (auto &&value : x) {
+    value = drand48() * 100;
+  }
+}
 
 static void Gemm_DR(benchmark::State &state) {
   auto q = get_queue();
@@ -36,3 +44,38 @@ static void Gemm_DR(benchmark::State &state) {
 }
 
 DR_BENCHMARK(Gemm_DR);
+
+static void Gemm_Reference(benchmark::State &state) {
+  auto q = get_queue();
+
+  std::size_t m = 32;
+  std::size_t n = 32;
+  std::size_t k = 32;
+
+  std::vector<T> a_local(m * k);
+  std::vector<T> b_local(k * n);
+  std::vector<T> c_local(m * n);
+
+  fill_random(a_local);
+  fill_random(b_local);
+  fill_random(c_local);
+
+  T *a = sycl::malloc_device<T>(m * k, q);
+  T *b = sycl::malloc_device<T>(k * n, q);
+  T *c = sycl::malloc_device<T>(m * n, q);
+
+  q.memcpy(a, a_local.data(), m * k * sizeof(T)).wait();
+  q.memcpy(b, b_local.data(), k * n * sizeof(T)).wait();
+  q.memcpy(c, c_local.data(), m * n * sizeof(T)).wait();
+
+  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T));
+
+  for (auto _ : state) {
+    stats.rep();
+    oneapi::mkl::blas::row_major::gemm(q, oneapi::mkl::transpose::nontrans,
+                                       oneapi::mkl::transpose::nontrans, m, n,
+                                       k, T(1), a, m, b, n, T(1), c, k);
+  }
+}
+
+DR_BENCHMARK(Gemm_Reference);

--- a/benchmarks/gbench/shp/gemm.cpp
+++ b/benchmarks/gbench/shp/gemm.cpp
@@ -16,12 +16,12 @@ template <rng::forward_range X> void fill_random(X &&x) {
   }
 }
 
+std::size_t m = 1000;
+std::size_t n = 1000;
+std::size_t k = 1000;
+
 static void Gemm_DR(benchmark::State &state) {
   auto q = get_queue();
-
-  std::size_t m = 32;
-  std::size_t n = 32;
-  std::size_t k = 32;
 
   auto partitions = dr::shp::partition_matmul(m, n, k);
   dr::shp::distributed_dense_matrix<T> a({m, k}, partitions[0]);
@@ -48,10 +48,6 @@ DR_BENCHMARK(Gemm_DR);
 static void Gemm_Reference(benchmark::State &state) {
   auto q = get_queue();
 
-  std::size_t m = 32;
-  std::size_t n = 32;
-  std::size_t k = 32;
-
   std::vector<T> a_local(m * k);
   std::vector<T> b_local(k * n);
   std::vector<T> c_local(m * n);
@@ -74,7 +70,8 @@ static void Gemm_Reference(benchmark::State &state) {
     stats.rep();
     oneapi::mkl::blas::row_major::gemm(q, oneapi::mkl::transpose::nontrans,
                                        oneapi::mkl::transpose::nontrans, m, n,
-                                       k, T(1), a, m, b, n, T(1), c, k);
+                                       k, T(1), a, m, b, n, T(1), c, k)
+        .wait();
   }
 }
 

--- a/benchmarks/gbench/shp/gemm.cpp
+++ b/benchmarks/gbench/shp/gemm.cpp
@@ -16,9 +16,9 @@ template <rng::forward_range X> void fill_random(X &&x) {
   }
 }
 
-std::size_t m = 1000;
-std::size_t n = 1000;
-std::size_t k = 1000;
+const std::size_t m = 16000;
+const std::size_t n = m;
+const std::size_t k = m;
 
 static void Gemm_DR(benchmark::State &state) {
   auto q = get_queue();
@@ -28,7 +28,7 @@ static void Gemm_DR(benchmark::State &state) {
   dr::shp::distributed_dense_matrix<T> b({k, n}, partitions[1]);
   dr::shp::distributed_dense_matrix<T> result({m, n}, partitions[2]);
 
-  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T));
+  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T), m * n * k);
   a[{2, 3}] = 12;
   a[{5, 7}] = 42;
   a[{8, 9}] = 37;
@@ -64,7 +64,7 @@ static void Gemm_Reference(benchmark::State &state) {
   q.memcpy(b, b_local.data(), k * n * sizeof(T)).wait();
   q.memcpy(c, c_local.data(), m * n * sizeof(T)).wait();
 
-  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T));
+  Stats stats(state, (m * k + k * n) * sizeof(T), m * n * sizeof(T), m * n * k);
 
   for (auto _ : state) {
     stats.rep();

--- a/benchmarks/gbench/shp/gemm.cpp
+++ b/benchmarks/gbench/shp/gemm.cpp
@@ -39,7 +39,7 @@ static void Gemm_DR(benchmark::State &state) {
 
   for (auto _ : state) {
     stats.rep();
-    dr::shp::gemm_inplace(a, b, result);
+    dr::shp::gemm(a, b, result);
   }
 }
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(MPI REQUIRED)
 find_package(MKL REQUIRED)
 find_package(TBB REQUIRED)
 target_link_libraries(dr_mpi INTERFACE MPI::MPI_CXX range-v3 std::mdspan
-                                       MKL::MKL TBB::tbb)
+                                       MKL::MKL_DPCPP TBB::tbb)
 
 # gcc 10 uses TBB API that were removed
 target_compile_definitions(dr_mpi INTERFACE _GLIBCXX_USE_TBB_PAR_BACKEND=0)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(MPI REQUIRED)
 find_package(MKL REQUIRED)
 find_package(TBB REQUIRED)
 target_link_libraries(dr_mpi INTERFACE MPI::MPI_CXX range-v3 std::mdspan
-                                       MKL::MKL_DPCPP TBB::tbb)
+                                       TBB::tbb)
 
 # gcc 10 uses TBB API that were removed
 target_compile_definitions(dr_mpi INTERFACE _GLIBCXX_USE_TBB_PAR_BACKEND=0)
@@ -37,8 +37,9 @@ add_library(dr_shp INTERFACE)
 add_library(DR::shp ALIAS dr_shp)
 
 target_include_directories(dr_shp INTERFACE . vendor)
-target_compile_definitions(dr_shp INTERFACE _GLIBCXX_USE_TBB_PAR_BACKEND=0)
-target_link_libraries(dr_shp INTERFACE range-v3 oneDPL fmt::fmt)
+target_compile_definitions(dr_shp INTERFACE USE_MKL
+                                            _GLIBCXX_USE_TBB_PAR_BACKEND=0)
+target_link_libraries(dr_shp INTERFACE range-v3 oneDPL fmt::fmt MKL::MKL_DPCPP)
 
 # For use, see:
 # https://github.com/illuhad/hipSYCL/blob/develop/doc/using-hipsycl.md#using-the-cmake-integration

--- a/include/dr/shp/algorithms/matrix/local_gemv.hpp
+++ b/include/dr/shp/algorithms/matrix/local_gemv.hpp
@@ -65,7 +65,7 @@ auto mkl_gemv(sycl::queue &q, csr_matrix_view<T, I, Args...> a, Iter b, Iter c,
   auto colind = dr::shp::__detail::local(a.colind_data());
   auto values = dr::shp::__detail::local(a.values_data());
 
-  oneapi::mkl::sparse::set_csr_data(a_handle, a.shape()[0], a.shape()[1],
+  oneapi::mkl::sparse::set_csr_data(q, a_handle, a.shape()[0], a.shape()[1],
                                     oneapi::mkl::index_base::zero, rowptr,
                                     colind, values);
 

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -77,6 +77,37 @@ template <typename T> struct Ops3 {
   LocalVec<T> vec0, vec1, vec2;
 };
 
+template <std::floating_point T>
+bool fp_equal(T a, T b, T epsilon = 128 * std::numeric_limits<T>::epsilon()) {
+  if (a == b) {
+    return true;
+  }
+
+  auto abs_th = std::numeric_limits<T>::min();
+
+  auto diff = std::abs(a - b);
+
+  auto norm =
+      std::min((std::abs(a) + std::abs(b)), std::numeric_limits<float>::max());
+  return diff < std::max(abs_th, epsilon * norm);
+}
+
+template <std::floating_point T>
+bool fp_equal(std::vector<T> a, std::vector<T> b,
+              T epsilon = 128 * std::numeric_limits<T>::epsilon()) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (std::size_t i = 0; i < a.size(); i++) {
+    if (!fp_equal(a[i], b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 template <rng::range R1, rng::range R2> bool is_equal(R1 &&r1, R2 &&r2) {
   if (rng::distance(rng::begin(r1), rng::end(r1)) !=
       rng::distance(rng::begin(r2), rng::end(r2))) {

--- a/test/gtest/shp/gemv.cpp
+++ b/test/gtest/shp/gemv.cpp
@@ -30,5 +30,6 @@ TEST(SparseMatrix, Gemv) {
     c_ref[i] += v;
   }
 
-  EXPECT_EQ(c_ref, c_local);
+  EXPECT_TRUE(fp_equal(c_ref, c_local))
+      << fmt::format("Reference:\n  {}\nActual:\n  {}\n", c_ref, c_local);
 }


### PR DESCRIPTION
Moved #515 here so I can update it.

I see this error if I make `m, n, k` bigger than 1000:
```
terminate called after throwing an instance of 'sycl::_V1::runtime_error'
  what():  Provided range is out of integer limits. Pass `-fno-sycl-id-queries-fit-in-int' to disable range check. -30 (PI_ERROR_INV\
ALID_VALUE)
```
@BenBrock: Have you seen this? I don't understand why a 2k x 2k matrix causes overflow. I see that shp uses a custom gemm and not MKL. Was there a problem?