### PR TITLE
disabled mhp Exclusive_Scan benchmarks

### DIFF
--- a/src-python/drbench/drbench/drbench.py
+++ b/src-python/drbench/drbench/drbench.py
@@ -441,14 +441,14 @@ def suite(
         "^Reduce_DR",
     ]
     dr_filters = dr_nop2p + dr_p2p
-    # ExclusiveScan benchmarks fail in SHP, so are enabled in MHP only
-    # see: https://github.com/oneapi-src/distributed-ranges/issues/593
-    mhp_filters = ["Stencil2D_DR", "WaveEquation_DR", "^Exclusive_Scan_DR"]
+    # ExclusiveScan benchmarks removed
+    # fail in SHP: https://github.com/oneapi-src/distributed-ranges/issues/593
+    # slow in MHP: https://github.com/oneapi-src/distributed-ranges/issues/588
+    mhp_filters = ["Stencil2D_DR", "WaveEquation_DR"]
     shp_filters = [".*Sort_DR", "Gemm_DR"]
     reference_filters = [
         "BlackScholes_Reference",
         "DotProduct_Reference",
-        "Exclusive_Scan_Reference",
         "Inclusive_Scan_Reference",
         "Reduce_Reference",
     ]

--- a/src-python/drbench/drbench/runner.py
+++ b/src-python/drbench/drbench/runner.py
@@ -31,8 +31,9 @@ class Runner:
             subprocess.run(command, shell=True, check=True)
         usage_end = resource.getrusage(resource.RUSAGE_CHILDREN)
         logging.info(
-            f"command execution time: "
-            f"{usage_end.ru_utime - usage_start.ru_utime}, "
+            f"command execution time, "
+            f"user:{usage_end.ru_utime - usage_start.ru_utime:.2f}, "
+            f"system:{usage_end.ru_stime - usage_start.ru_stime:.2f}, "
             f"command: {command}"
         )
 


### PR DESCRIPTION
disabled because they are very slow in mhp, see: https://github.com/oneapi-src/distributed-ranges/issues/588