### PR TITLE
do not serialize ci jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,6 @@ jobs:
 
   gcc:
     runs-on: ${{ github.repository_owner == 'oneapi-src' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
-    needs: checks
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +71,6 @@ jobs:
 
   icpx:
     runs-on: devcloud
-    needs: checks
     timeout-minutes: 60
     # MPI device memory does not work
     env:
@@ -90,7 +88,7 @@ jobs:
         path: build/Testing
 
   publish:
-    needs: [gcc, icpx]
+    needs: [checks, gcc, icpx]
     runs-on: ${{ github.repository_owner == 'oneapi-src' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     env:
       SPHINXOPTS: -q -W


### PR DESCRIPTION
I serialized CI jobs to reduce runner usage. I thought it would only add 2 minutes to the total time. I found that intel-unbuntu-latest always takes 4+ minutes to spin up, adding 10 minutes to total time. Do checks, g++, and icpx in parallel.