### PR TITLE
DRA-89 fixed (Bug in exclusive_scan for input ranges of small size)

### DIFF
--- a/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
+++ b/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
@@ -39,14 +39,8 @@ void local_exclusive_scan(auto policy, auto in, auto out, auto binary_op,
   auto out_begin_direct = detail::direct_iterator(out.begin());
 
   if (seg_index != 0) {
-    // assert(rng::size(in) > 1);
-    // assert(rng::size(out) > 1);
-
-    // if (rng::size(in) <= 1) {
-    fmt::print("{}:{}/{} local_exclusive_scan size in {} size out {}\n",
-               default_comm().rank(), __LINE__, default_comm().size(),
-               rng::size(in), rng::size(out));
-    // }
+    assert(rng::size(in) > 1);
+    assert(rng::size(out) > 1);
     --in_end_direct;
     ++out_begin_direct;
     std::inclusive_scan(policy, in_begin_direct, in_end_direct,

--- a/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
+++ b/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
@@ -77,7 +77,8 @@ auto inclusive_exclusive_scan_impl_(R &&r, O &&d_first, BinaryOp &&binary_op,
       } else {
         std::inclusive_scan(detail::direct_iterator(vec_in.begin()),
                             detail::direct_iterator(vec_in.end()),
-                            detail::direct_iterator(vec_out.begin()), binary_op);
+                            detail::direct_iterator(vec_out.begin()),
+                            binary_op);
       }
     }
     mhp::copy(0, vec_out, d_first);

--- a/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
+++ b/include/dr/mhp/algorithms/inclusive_exclusive_scan_impl.hpp
@@ -100,8 +100,6 @@ auto inclusive_exclusive_scan_impl_(R &&r, O &&d_first, BinaryOp &&binary_op,
     return d_first + rng::size(r);
   }
 
-  fmt::print("{}:{}/{} Parallel scan, r.size \n", default_comm().rank(),
-             __LINE__, default_comm().size(), rng::size(r));
   auto rank = comm.rank();
   auto local_segs = rng::views::zip(local_segments(r), local_segments(d_first));
   auto global_segs =

--- a/test/gtest/common/exclusive_scan.cpp
+++ b/test/gtest/common/exclusive_scan.cpp
@@ -13,9 +13,9 @@ public:
 TYPED_TEST_SUITE(ExclusiveScan, AllTypesWithoutIshmem);
 
 TYPED_TEST(ExclusiveScan, whole_range) {
-  TypeParam dv_in(7);
+  TypeParam dv_in(15);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(7, 0);
+  TypeParam dv_out(15, 0);
 
   xhp::exclusive_scan(dv_in, dv_out, 10, std::plus<>());
   EXPECT_EQ(10, dv_out[0]);
@@ -25,6 +25,16 @@ TYPED_TEST(ExclusiveScan, whole_range) {
   EXPECT_EQ(10 + 1 + 2 + 3 + 4, dv_out[4]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5, dv_out[5]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6, dv_out[6]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7, dv_out[7]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[8]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[9]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[10]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11, dv_out[11]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12, dv_out[12]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13,
+            dv_out[13]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14,
+            dv_out[14]);
 }
 
 TYPED_TEST(ExclusiveScan, whole_range_small) {
@@ -39,8 +49,8 @@ TYPED_TEST(ExclusiveScan, whole_range_small) {
 }
 
 TYPED_TEST(ExclusiveScan, empty) {
-  TypeParam dv_in(5, 1);
-  TypeParam dv_out(5, 0);
+  TypeParam dv_in(11, 1);
+  TypeParam dv_out(11, 0);
   xhp::exclusive_scan(rng::begin(dv_in), rng::begin(dv_in), rng::begin(dv_out),
                       0);
   EXPECT_EQ(0, dv_out[0]);
@@ -48,22 +58,36 @@ TYPED_TEST(ExclusiveScan, empty) {
   EXPECT_EQ(0, dv_out[2]);
   EXPECT_EQ(0, dv_out[3]);
   EXPECT_EQ(0, dv_out[4]);
+  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(0, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, one_element) {
-  TypeParam dv_in(3, 1);
-  TypeParam dv_out(3, 0);
+  TypeParam dv_in(11, 1);
+  TypeParam dv_out(11, 0);
   xhp::exclusive_scan(rng::begin(dv_in), ++rng::begin(dv_in),
                       rng::begin(dv_out), 0);
   EXPECT_EQ(0, dv_out[0]);
   EXPECT_EQ(0, dv_out[1]);
   EXPECT_EQ(0, dv_out[2]);
+  EXPECT_EQ(0, dv_out[3]);
+  EXPECT_EQ(0, dv_out[4]);
+  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(0, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, multiply) {
-  TypeParam dv_in(7);
+  TypeParam dv_in(15);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(7, 0);
+  TypeParam dv_out(15, 0);
 
   xhp::exclusive_scan(dv_in, dv_out, 1, std::multiplies<>());
 
@@ -74,6 +98,16 @@ TYPED_TEST(ExclusiveScan, multiply) {
   EXPECT_EQ(1 * 2 * 3 * 4, dv_out[4]);
   EXPECT_EQ(1 * 2 * 3 * 4 * 5, dv_out[5]);
   EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6, dv_out[6]);
+  EXPECT_EQ(1 * 1 *2 *3 *4 *5 *6 *7, dv_out[7]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8, dv_out[8]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9, dv_out[9]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10, dv_out[10]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11, dv_out[11]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12, dv_out[12]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12 * 13,
+            dv_out[13]);
+  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12 * 13 * 14,
+            dv_out[14]);
 }
 
 TYPED_TEST(ExclusiveScan, multiply_small) {
@@ -89,9 +123,9 @@ TYPED_TEST(ExclusiveScan, multiply_small) {
 }
 
 TYPED_TEST(ExclusiveScan, touching_first_segment) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::exclusive_scan(rng::begin(dv_in), ++(++rng::begin(dv_in)),
                       rng::begin(dv_out), 0);
@@ -101,12 +135,17 @@ TYPED_TEST(ExclusiveScan, touching_first_segment) {
   EXPECT_EQ(0, dv_out[3]);
   EXPECT_EQ(0, dv_out[4]);
   EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(0, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, touching_last_segment) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::exclusive_scan(--(--rng::end(dv_in)), rng::end(dv_in),
                       --(--rng::end(dv_out)), 0);
@@ -115,13 +154,18 @@ TYPED_TEST(ExclusiveScan, touching_last_segment) {
   EXPECT_EQ(0, dv_out[2]);
   EXPECT_EQ(0, dv_out[3]);
   EXPECT_EQ(0, dv_out[4]);
-  EXPECT_EQ(5, dv_out[5]);
+  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(0, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, without_last_element) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::exclusive_scan(rng::begin(dv_in), --rng::end(dv_in), rng::begin(dv_out),
                       0);
@@ -130,13 +174,18 @@ TYPED_TEST(ExclusiveScan, without_last_element) {
   EXPECT_EQ(1 + 2, dv_out[2]);
   EXPECT_EQ(1 + 2 + 3, dv_out[3]);
   EXPECT_EQ(1 + 2 + 3 + 4, dv_out[4]);
-  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5, dv_out[5]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6, dv_out[6]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7, dv_out[7]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[8]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, without_first_element) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::exclusive_scan(++rng::begin(dv_in), rng::end(dv_in),
                       ++rng::begin(dv_out), 0);
@@ -146,12 +195,17 @@ TYPED_TEST(ExclusiveScan, without_first_element) {
   EXPECT_EQ(2 + 3, dv_out[3]);
   EXPECT_EQ(2 + 3 + 4, dv_out[4]);
   EXPECT_EQ(2 + 3 + 4 + 5, dv_out[5]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6, dv_out[6]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7, dv_out[7]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[8]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[9]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, without_first_and_last_elements) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::exclusive_scan(++rng::begin(dv_in), --rng::end(dv_in),
                       ++rng::begin(dv_out), 0);
@@ -160,5 +214,11 @@ TYPED_TEST(ExclusiveScan, without_first_and_last_elements) {
   EXPECT_EQ(2, dv_out[2]);
   EXPECT_EQ(2 + 3, dv_out[3]);
   EXPECT_EQ(2 + 3 + 4, dv_out[4]);
+  EXPECT_EQ(2 + 3 + 4 + 5, dv_out[5]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6, dv_out[6]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7, dv_out[7]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[8]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[9]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[10]);
   EXPECT_EQ(0, dv_out[5]);
 }

--- a/test/gtest/common/exclusive_scan.cpp
+++ b/test/gtest/common/exclusive_scan.cpp
@@ -85,9 +85,9 @@ TYPED_TEST(ExclusiveScan, one_element) {
 }
 
 TYPED_TEST(ExclusiveScan, multiply) {
-  TypeParam dv_in(15);
+  TypeParam dv_in(13);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(15, 0);
+  TypeParam dv_out(13, 0);
 
   xhp::exclusive_scan(dv_in, dv_out, 1, std::multiplies<>());
 
@@ -98,16 +98,12 @@ TYPED_TEST(ExclusiveScan, multiply) {
   EXPECT_EQ(1 * 2 * 3 * 4, dv_out[4]);
   EXPECT_EQ(1 * 2 * 3 * 4 * 5, dv_out[5]);
   EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6, dv_out[6]);
-  EXPECT_EQ(1 * 1 *2 *3 *4 *5 *6 *7, dv_out[7]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8, dv_out[8]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9, dv_out[9]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10, dv_out[10]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11, dv_out[11]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12, dv_out[12]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12 * 13,
-            dv_out[13]);
-  EXPECT_EQ(1 * 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12 * 13 * 14,
-            dv_out[14]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7, dv_out[7]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8, dv_out[8]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9, dv_out[9]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10, dv_out[10]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11, dv_out[11]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10 * 11 * 12, dv_out[12]);
 }
 
 TYPED_TEST(ExclusiveScan, multiply_small) {
@@ -159,7 +155,7 @@ TYPED_TEST(ExclusiveScan, touching_last_segment) {
   EXPECT_EQ(0, dv_out[7]);
   EXPECT_EQ(0, dv_out[8]);
   EXPECT_EQ(0, dv_out[9]);
-  EXPECT_EQ(0, dv_out[10]);
+  EXPECT_EQ(10, dv_out[10]);
 }
 
 TYPED_TEST(ExclusiveScan, without_last_element) {
@@ -219,6 +215,5 @@ TYPED_TEST(ExclusiveScan, without_first_and_last_elements) {
   EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7, dv_out[7]);
   EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[8]);
   EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[9]);
-  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[10]);
-  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[10]);
 }

--- a/test/gtest/common/exclusive_scan.cpp
+++ b/test/gtest/common/exclusive_scan.cpp
@@ -13,9 +13,9 @@ public:
 TYPED_TEST_SUITE(ExclusiveScan, AllTypesWithoutIshmem);
 
 TYPED_TEST(ExclusiveScan, whole_range) {
-  TypeParam dv_in(5);
+  TypeParam dv_in(7);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(5, 0);
+  TypeParam dv_out(7, 0);
 
   xhp::exclusive_scan(dv_in, dv_out, 10, std::plus<>());
   EXPECT_EQ(10, dv_out[0]);
@@ -23,16 +23,31 @@ TYPED_TEST(ExclusiveScan, whole_range) {
   EXPECT_EQ(10 + 1 + 2, dv_out[2]);
   EXPECT_EQ(10 + 1 + 2 + 3, dv_out[3]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4, dv_out[4]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5, dv_out[5]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6, dv_out[6]);
+}
+
+TYPED_TEST(ExclusiveScan, whole_range_small) {
+  TypeParam dv_in(3);
+  xhp::iota(dv_in, 1);
+  TypeParam dv_out(3, 0);
+
+  xhp::exclusive_scan(dv_in, dv_out, 10, std::plus<>());
+  EXPECT_EQ(10, dv_out[0]);
+  EXPECT_EQ(10 + 1, dv_out[1]);
+  EXPECT_EQ(10 + 1 + 2, dv_out[2]);
 }
 
 TYPED_TEST(ExclusiveScan, empty) {
-  TypeParam dv_in(3, 1);
-  TypeParam dv_out(3, 0);
+  TypeParam dv_in(5, 1);
+  TypeParam dv_out(5, 0);
   xhp::exclusive_scan(rng::begin(dv_in), rng::begin(dv_in), rng::begin(dv_out),
                       0);
   EXPECT_EQ(0, dv_out[0]);
   EXPECT_EQ(0, dv_out[1]);
   EXPECT_EQ(0, dv_out[2]);
+  EXPECT_EQ(0, dv_out[3]);
+  EXPECT_EQ(0, dv_out[4]);
 }
 
 TYPED_TEST(ExclusiveScan, one_element) {
@@ -46,9 +61,9 @@ TYPED_TEST(ExclusiveScan, one_element) {
 }
 
 TYPED_TEST(ExclusiveScan, multiply) {
-  TypeParam dv_in(5);
+  TypeParam dv_in(7);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(5, 0);
+  TypeParam dv_out(7, 0);
 
   xhp::exclusive_scan(dv_in, dv_out, 1, std::multiplies<>());
 
@@ -57,6 +72,20 @@ TYPED_TEST(ExclusiveScan, multiply) {
   EXPECT_EQ(1 * 2, dv_out[2]);
   EXPECT_EQ(1 * 2 * 3, dv_out[3]);
   EXPECT_EQ(1 * 2 * 3 * 4, dv_out[4]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5, dv_out[5]);
+  EXPECT_EQ(1 * 2 * 3 * 4 * 5 * 6, dv_out[6]);
+}
+
+TYPED_TEST(ExclusiveScan, multiply_small) {
+  TypeParam dv_in(3);
+  xhp::iota(dv_in, 1);
+  TypeParam dv_out(3, 0);
+
+  xhp::exclusive_scan(dv_in, dv_out, 1, std::multiplies<>());
+
+  EXPECT_EQ(1, dv_out[0]);
+  EXPECT_EQ(1, dv_out[1]);
+  EXPECT_EQ(1 * 2, dv_out[2]);
 }
 
 TYPED_TEST(ExclusiveScan, touching_first_segment) {

--- a/test/gtest/common/inclusive_scan.cpp
+++ b/test/gtest/common/inclusive_scan.cpp
@@ -13,9 +13,9 @@ public:
 TYPED_TEST_SUITE(InclusiveScan, AllTypesWithoutIshmem);
 
 TYPED_TEST(InclusiveScan, whole_range) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(15);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(15, 0);
 
   xhp::inclusive_scan(dv_in, dv_out, std::plus<>());
   EXPECT_EQ(1, dv_out[0]);
@@ -24,6 +24,17 @@ TYPED_TEST(InclusiveScan, whole_range) {
   EXPECT_EQ(1 + 2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(1 + 2 + 3 + 4 + 5, dv_out[4]);
   EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6, dv_out[5]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7, dv_out[6]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[7]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[8]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[9]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11, dv_out[10]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12, dv_out[11]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13, dv_out[12]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14,
+            dv_out[13]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15,
+            dv_out[14]);
 }
 
 TYPED_TEST(InclusiveScan, whole_range_small) {
@@ -38,9 +49,9 @@ TYPED_TEST(InclusiveScan, whole_range_small) {
 }
 
 TYPED_TEST(InclusiveScan, whole_range_with_init_value) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(dv_in, dv_out, std::plus<>(), 10);
   EXPECT_EQ(10 + 1, dv_out[0]);
@@ -49,6 +60,11 @@ TYPED_TEST(InclusiveScan, whole_range_with_init_value) {
   EXPECT_EQ(10 + 1 + 2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5, dv_out[4]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6, dv_out[5]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7, dv_out[6]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[7]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[8]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[9]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11, dv_out[10]);
 }
 
 TYPED_TEST(InclusiveScan, whole_range_with_init_value_small) {
@@ -96,9 +112,9 @@ TYPED_TEST(InclusiveScan, multiply) {
 }
 
 TYPED_TEST(InclusiveScan, touching_first_segment) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(rng::begin(dv_in), ++(++rng::begin(dv_in)),
                       rng::begin(dv_out), std::plus<>());
@@ -108,12 +124,17 @@ TYPED_TEST(InclusiveScan, touching_first_segment) {
   EXPECT_EQ(0, dv_out[3]);
   EXPECT_EQ(0, dv_out[4]);
   EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(0, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(InclusiveScan, touching_last_segment) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(--(--rng::end(dv_in)), rng::end(dv_in),
                       --(--rng::end(dv_out)));
@@ -121,14 +142,19 @@ TYPED_TEST(InclusiveScan, touching_last_segment) {
   EXPECT_EQ(0, dv_out[1]);
   EXPECT_EQ(0, dv_out[2]);
   EXPECT_EQ(0, dv_out[3]);
-  EXPECT_EQ(5, dv_out[4]);
-  EXPECT_EQ(5 + 6, dv_out[5]);
+  EXPECT_EQ(0, dv_out[4]);
+  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(0, dv_out[6]);
+  EXPECT_EQ(0, dv_out[7]);
+  EXPECT_EQ(0, dv_out[8]);
+  EXPECT_EQ(10, dv_out[9]);
+  EXPECT_EQ(10 + 11, dv_out[10]);
 }
 
 TYPED_TEST(InclusiveScan, without_last_element) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(rng::begin(dv_in), --rng::end(dv_in), rng::begin(dv_out));
   EXPECT_EQ(1, dv_out[0]);
@@ -136,13 +162,18 @@ TYPED_TEST(InclusiveScan, without_last_element) {
   EXPECT_EQ(1 + 2 + 3, dv_out[2]);
   EXPECT_EQ(1 + 2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(1 + 2 + 3 + 4 + 5, dv_out[4]);
-  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6, dv_out[5]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7, dv_out[6]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[7]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[8]);
+  EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }
 
 TYPED_TEST(InclusiveScan, without_first_element) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(++rng::begin(dv_in), rng::end(dv_in),
                       ++rng::begin(dv_out));
@@ -152,12 +183,16 @@ TYPED_TEST(InclusiveScan, without_first_element) {
   EXPECT_EQ(2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(2 + 3 + 4 + 5, dv_out[4]);
   EXPECT_EQ(2 + 3 + 4 + 5 + 6, dv_out[5]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7, dv_out[6]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[7]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[8]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[9]);
 }
 
 TYPED_TEST(InclusiveScan, without_first_and_last_elements) {
-  TypeParam dv_in(6);
+  TypeParam dv_in(11);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(6, 0);
+  TypeParam dv_out(11, 0);
 
   xhp::inclusive_scan(++rng::begin(dv_in), --rng::end(dv_in),
                       ++rng::begin(dv_out));
@@ -166,5 +201,10 @@ TYPED_TEST(InclusiveScan, without_first_and_last_elements) {
   EXPECT_EQ(2 + 3, dv_out[2]);
   EXPECT_EQ(2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(2 + 3 + 4 + 5, dv_out[4]);
-  EXPECT_EQ(0, dv_out[5]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6, dv_out[5]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7, dv_out[6]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8, dv_out[7]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9, dv_out[8]);
+  EXPECT_EQ(2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10, dv_out[9]);
+  EXPECT_EQ(0, dv_out[10]);
 }

--- a/test/gtest/common/inclusive_scan.cpp
+++ b/test/gtest/common/inclusive_scan.cpp
@@ -26,10 +26,21 @@ TYPED_TEST(InclusiveScan, whole_range) {
   EXPECT_EQ(1 + 2 + 3 + 4 + 5 + 6, dv_out[5]);
 }
 
-TYPED_TEST(InclusiveScan, whole_range_with_init_value) {
-  TypeParam dv_in(5);
+TYPED_TEST(InclusiveScan, whole_range_small) {
+  TypeParam dv_in(3);
   xhp::iota(dv_in, 1);
-  TypeParam dv_out(5, 0);
+  TypeParam dv_out(3, 0);
+
+  xhp::inclusive_scan(dv_in, dv_out, std::plus<>());
+  EXPECT_EQ(1, dv_out[0]);
+  EXPECT_EQ(1 + 2, dv_out[1]);
+  EXPECT_EQ(1 + 2 + 3, dv_out[2]);
+}
+
+TYPED_TEST(InclusiveScan, whole_range_with_init_value) {
+  TypeParam dv_in(6);
+  xhp::iota(dv_in, 1);
+  TypeParam dv_out(6, 0);
 
   xhp::inclusive_scan(dv_in, dv_out, std::plus<>(), 10);
   EXPECT_EQ(10 + 1, dv_out[0]);
@@ -37,6 +48,18 @@ TYPED_TEST(InclusiveScan, whole_range_with_init_value) {
   EXPECT_EQ(10 + 1 + 2 + 3, dv_out[2]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4, dv_out[3]);
   EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5, dv_out[4]);
+  EXPECT_EQ(10 + 1 + 2 + 3 + 4 + 5 + 6, dv_out[5]);
+}
+
+TYPED_TEST(InclusiveScan, whole_range_with_init_value_small) {
+  TypeParam dv_in(3);
+  xhp::iota(dv_in, 1);
+  TypeParam dv_out(3, 0);
+
+  xhp::inclusive_scan(dv_in, dv_out, std::plus<>(), 10);
+  EXPECT_EQ(10 + 1, dv_out[0]);
+  EXPECT_EQ(10 + 1 + 2, dv_out[1]);
+  EXPECT_EQ(10 + 1 + 2 + 3, dv_out[2]);
 }
 
 TYPED_TEST(InclusiveScan, empty) {

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -56,7 +56,7 @@ add_executable(
 
 add_executable(mhp-quick-test
   mhp-tests.cpp
-  ../common/inclusive_scan.cpp
+  ../common/exclusive_scan.cpp
   )
 # cmake-format: on
 

--- a/test/gtest/mhp/CMakeLists.txt
+++ b/test/gtest/mhp/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(
 add_executable(mhp-quick-test
   mhp-tests.cpp
   ../common/exclusive_scan.cpp
+  ../common/inclusive_scan.cpp
   )
 # cmake-format: on
 


### PR DESCRIPTION
For small input vectors  (smaller than  2 * size(r)) sequential function is bug-safe.