### PR TITLE
benchmarks framework refactoring

### DIFF
--- a/benchmarks/gbench/CMakeLists.txt
+++ b/benchmarks/gbench/CMakeLists.txt
@@ -8,10 +8,12 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   #
   set(BENCHMARK_ENABLE_TESTING off)
   set(BENCHMARK_ENABLE_WERROR off)
+  # oneApi 2024.1 compiler refuses to compile code with standard less than C++17
+  set(BENCHMARK_CXX_STANDARD 20)
   FetchContent_Declare(
     googlebench
-    GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.8.0)
+    GIT_REPOSITORY https://github.com/lslusarczyk/benchmark.git
+    GIT_TAG set-cxx-std)
   FetchContent_MakeAvailable(googlebench)
 
   if(ENABLE_CUDA)

--- a/benchmarks/gbench/shp/shp-bench.cpp
+++ b/benchmarks/gbench/shp/shp-bench.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
     ("check", "Check results")
     ("d, num-devices", "number of sycl devices, 0 uses all available devices", cxxopts::value<std::size_t>()->default_value("0"))
     ("drhelp", "Print help")
+    ("different-devices", "ensure no multiple ranks on one device")
     ("reps", "Debug repetitions for short duration vector operations", cxxopts::value<std::size_t>()->default_value("1"))
     ("vector-size", "Default vector size", cxxopts::value<std::size_t>()->default_value("100000000"))
     ("context", "Additional google benchmark context", cxxopts::value<std::vector<std::string>>())
@@ -64,6 +65,7 @@ int main(int argc, char *argv[]) {
   default_repetitions = options["reps"].as<std::size_t>();
   ranks = options["num-devices"].as<std::size_t>();
   weak_scaling = options["weak-scaling"].as<bool>();
+  const bool check_different_devices = options.count("different-devices");
 
   auto available_devices = dr::shp::get_numa_devices(sycl::default_selector_v);
   if (ranks == 0) {
@@ -77,6 +79,7 @@ int main(int argc, char *argv[]) {
 
   if (!dry_run) {
     std::vector<sycl::device> devices;
+    assert(!check_different_devices || ranks <= available_devices.size());
     for (std::size_t i = 0; i < ranks; i++) {
       devices.push_back(available_devices[i % available_devices.size()]);
       benchmark::AddCustomContext("device_info" + std::to_string(i),

--- a/src-python/drbench/pyproject.toml
+++ b/src-python/drbench/pyproject.toml
@@ -11,7 +11,7 @@ name = "drbench"
 version = "0.0.1"
 description = "Benchmarking framework for distributed ranges project"
 dependencies = [
-    "click", "seaborn", "pandas",
+    "click", "matplotlib", "pandas",
     'importlib-metadata; python_version<"3.8"',
 ]
 [project.scripts]


### PR DESCRIPTION
- added possibility to runbenchmarks under icpx compiler from 2024.1 oneapi
- retrying failed benchmarking for limited time
- different-devices option supported on shp
- running benchmarks by mpiexec pointed by current I_MPI_ROOT, not by the path
- limited shp FFT3D_DR to 4 gpus as it fails with OUT_OF_RESOURCES if executed on more devices
- removed seaborn dependency from drbench package