### PR TITLE
Support for input vectors bigger that 2GB

### DIFF
--- a/benchmarks/gbench/common/sort.cpp
+++ b/benchmarks/gbench/common/sort.cpp
@@ -15,38 +15,38 @@ template <rng::forward_range X> void fill_random(X &&x) {
 class DRSortFixture : public benchmark::Fixture {
 protected:
   xhp::distributed_vector<T> *a;
+  xhp::distributed_vector<T> *vec;
   std::vector<T> local_vec;
 
 public:
   void SetUp(::benchmark::State &) {
     a = new xhp::distributed_vector<T>(default_vector_size);
+    vec = new xhp::distributed_vector<T>(default_vector_size);
     local_vec = std::vector<T>(default_vector_size);
     fill_random(local_vec);
     xhp::copy(local_vec, rng::begin(*a));
   }
 
   void TearDown(::benchmark::State &state) {
-    xhp::copy(*a, rng::begin(local_vec));
+    // copy back to check if last sort really sorted
+    xhp::copy(*vec, rng::begin(local_vec));
+    delete a;
+    delete vec;
 
     if (!rng::is_sorted(local_vec)) {
       state.SkipWithError("mhp sort did not sort the vector");
-    } else {
-      std::cout << "\n *** mhp::sort did it! ***\n\n";
     }
-
-    delete a;
   }
 };
 
 BENCHMARK_DEFINE_F(DRSortFixture, Sort_DR)(benchmark::State &state) {
   Stats stats(state, sizeof(T) * a->size());
-  xhp::distributed_vector<T> vec(a->size());
   for (auto _ : state) {
     state.PauseTiming();
-    xhp::copy(*a, rng::begin(vec));
+    xhp::copy(*a, rng::begin(*vec));
     stats.rep();
     state.ResumeTiming();
-    xhp::sort(vec);
+    xhp::sort(*vec);
   }
 }
 

--- a/include/dr/detail/communicator.hpp
+++ b/include/dr/detail/communicator.hpp
@@ -207,9 +207,10 @@ public:
     rng::transform(recvdsp, _recvdsp.begin(),
                    [](auto e) { return e * sizeof(valT); });
 
-    MPI_Alltoallv_c(rng::data(sendbuf), rng::data(_sendcnt), rng::data(_senddsp),
-                  MPI_BYTE, rng::data(recvbuf), rng::data(_recvcnt),
-                  rng::data(_recvdsp), MPI_BYTE, mpi_comm_);
+    MPI_Alltoallv_c(rng::data(sendbuf), rng::data(_sendcnt),
+                    rng::data(_senddsp), MPI_BYTE, rng::data(recvbuf),
+                    rng::data(_recvcnt), rng::data(_recvdsp), MPI_BYTE,
+                    mpi_comm_);
   }
 
   bool operator==(const communicator &other) const {
@@ -254,7 +255,8 @@ public:
            std::size_t disp) const {
     DRLOG("MPI comm get:: ({}:{}:{})", rank, disp, size);
     MPI_Request request;
-#if (MPI_VERSION >= 4) || (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rget_c(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
     assert(
@@ -274,7 +276,8 @@ public:
     DRLOG("MPI comm put:: ({}:{}:{})", rank, disp, (int)size);
     MPI_Request request;
 
-#if (MPI_VERSION >= 4) || (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rput_c(src, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
     // MPI_Rput origin_count is 32-bit signed int - check range

--- a/include/dr/detail/communicator.hpp
+++ b/include/dr/detail/communicator.hpp
@@ -259,8 +259,8 @@ public:
            std::size_t disp) const {
     DRLOG("MPI comm get:: ({}:{}:{})", rank, disp, size);
     MPI_Request request;
-#if (MPI_VERSION >= 4) ||                                                        \
-      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rget_c(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
     assert(

--- a/include/dr/detail/communicator.hpp
+++ b/include/dr/detail/communicator.hpp
@@ -259,7 +259,8 @@ public:
            std::size_t disp) const {
     DRLOG("MPI comm get:: ({}:{}:{})", rank, disp, size);
     MPI_Request request;
-#if MPI_SUPPORTS_RGET_C
+#if (MPI_VERSION >= 4) ||                                                        \
+      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rget_c(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
     assert(
@@ -279,7 +280,8 @@ public:
     DRLOG("MPI comm put:: ({}:{}:{})", rank, disp, size);
     MPI_Request request;
 
-#if MPI_SUPPORTS_RGET_C
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rput_c(src, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
     // MPI_Rput origin_count is 32-bit signed int - check range

--- a/include/dr/detail/communicator.hpp
+++ b/include/dr/detail/communicator.hpp
@@ -257,7 +257,6 @@ public:
 #if (MPI_VERSION >= 4) || (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     MPI_Rget_c(dst, size, MPI_BYTE, rank, disp, size, MPI_BYTE, win_, &request);
 #else
-    // MPI_Rget origin_count is 32-bit signed int - check range
     assert(
         size <= (std::size_t)INT_MAX &&
         "MPI API requires origin_count to be positive signed 32-bit integer");

--- a/include/dr/mhp/algorithms/sort.hpp
+++ b/include/dr/mhp/algorithms/sort.hpp
@@ -376,7 +376,8 @@ void dist_sort(R &r, Compare &&comp) {
   std::vector<std::size_t> vec_recv_elems(_comm_size, 0);
   std::size_t _total_elems = 0;
 
-  DRLOG("Rank {}: Dist sort, local segment size {}", default_comm().rank(), rng::size(lsegment));
+  DRLOG("Rank {}: Dist sort, local segment size {}", default_comm().rank(),
+        rng::size(lsegment));
 
   __detail::local_sort(lsegment, comp);
 
@@ -431,7 +432,7 @@ void dist_sort(R &r, Compare &&comp) {
    * lsegment size */
   __detail::shift_data<valT>(shift_left, shift_right, vec_recvdata, vec_left,
                              vec_right);
-  
+
   /* copy results to distributed vector's local segment */
   __detail::copy_results<valT>(lsegment, shift_left, shift_right, vec_recvdata,
                                vec_left, vec_right);

--- a/include/dr/mhp/algorithms/sort.hpp
+++ b/include/dr/mhp/algorithms/sort.hpp
@@ -126,9 +126,11 @@ template <typename R, typename Compare> void local_sort(R &r, Compare &&comp) {
       auto policy = dpl_policy();
       auto &&local_segment = dr::ranges::__detail::local(r);
       DRLOG("GPU dpl::sort(), size {}", rng::size(r));
+      LOG;
       oneapi::dpl::sort(
           policy, dr::__detail::direct_iterator(rng::begin(local_segment)),
           dr::__detail::direct_iterator(rng::end(local_segment)), comp);
+      LOG;
 #else
       assert(false);
 #endif

--- a/include/dr/mhp/algorithms/sort.hpp
+++ b/include/dr/mhp/algorithms/sort.hpp
@@ -410,8 +410,8 @@ void dist_sort(R &r, Compare &&comp) {
   /* send and receive data belonging to each node, then redistribute
    * data to achieve size of data equal to size of local segment */
   LOG;
-  MPI_Request req_recvelems;
-  default_comm().i_all_gather(_recv_elems, vec_recv_elems, &req_recvelems);
+  // MPI_Request req_recvelems;
+  default_comm().all_gather(_recv_elems, vec_recv_elems);
 
   /* buffer for received data */
   buffer<valT> vec_recvdata(_recv_elems);
@@ -425,7 +425,7 @@ void dist_sort(R &r, Compare &&comp) {
    * desirable */
   LOG;
   __detail::local_sort(vec_recvdata, comp);
-  MPI_Wait(&req_recvelems, MPI_STATUS_IGNORE);
+  // MPI_Wait(&req_recvelems, MPI_STATUS_IGNORE);
 
   _total_elems = std::reduce(vec_recv_elems.begin(), vec_recv_elems.end());
 

--- a/include/dr/mhp/algorithms/sort.hpp
+++ b/include/dr/mhp/algorithms/sort.hpp
@@ -24,6 +24,10 @@
 
 namespace dr::mhp {
 
+bool _is_sorted(std::ranges::forward_range auto &r) {
+  return std::is_sorted(dpl_policy(), rng::begin(r), rng::end(r));
+}
+
 namespace __detail {
 
 template <typename T> class buffer {
@@ -133,6 +137,7 @@ template <typename R, typename Compare> void local_sort(R &r, Compare &&comp) {
       DRLOG("cpu rng::sort, size {}", rng::size(r));
       rng::sort(rng::begin(r), rng::end(r), comp);
     }
+    assert(_is_sorted(r));
   }
 }
 
@@ -231,7 +236,7 @@ void splitters(Seg &lsegment, Compare &&comp,
 }
 
 template <typename valT>
-void shift_data(const int shift_left, const int shift_right,
+void shift_data(const int64_t shift_left, const int64_t shift_right,
                 buffer<valT> &vec_recvdata, buffer<valT> &vec_left,
                 buffer<valT> &vec_right) {
 
@@ -240,17 +245,18 @@ void shift_data(const int shift_left, const int shift_right,
   MPI_Request req_l, req_r;
   MPI_Status stat_l, stat_r;
 
-  assert(static_cast<int>(rng::size(vec_left)) == std::max(0, shift_left));
-  assert(static_cast<int>(rng::size(vec_right)) == std::max(0, shift_right));
+  assert(static_cast<int64_t>(rng::size(vec_left)) == std::max(0L, shift_left));
+  assert(static_cast<int64_t>(rng::size(vec_right)) ==
+         std::max(0L, shift_right));
 
-  if (static_cast<int>(rng::size(vec_recvdata)) < -shift_left) {
+  if (static_cast<int64_t>(rng::size(vec_recvdata)) < -shift_left) {
     // Too little data in recv buffer to shift left - first get from right,
     // then send left
     DRLOG("Get from right first, recvdata size {} shift left {}",
           rng::size(vec_recvdata), shift_left);
     // ** This will never happen, because values eq to split go left **
     assert(false);
-  } else if (static_cast<int>(rng::size(vec_recvdata)) < -shift_right) {
+  } else if (static_cast<int64_t>(rng::size(vec_recvdata)) < -shift_right) {
     // Too little data in buffer to shift right - first get from left, then
     // send right
     assert(shift_left > 0);
@@ -285,13 +291,13 @@ void shift_data(const int shift_left, const int shift_right,
       default_comm().isend(rng::data(vec_recvdata), -shift_left, _comm_rank - 1,
                            &req_l);
     } else if (shift_left > 0) {
-      assert(shift_left == static_cast<int>(rng::size(vec_left)));
+      assert(shift_left == static_cast<int64_t>(rng::size(vec_left)));
       default_comm().irecv(rng::data(vec_left), rng::size(vec_left),
                            _comm_rank - 1, &req_l);
     }
 
     if (shift_right > 0) {
-      assert(shift_right == static_cast<int>(rng::size(vec_right)));
+      assert(shift_right == static_cast<int64_t>(rng::size(vec_right)));
       default_comm().irecv(rng::data(vec_right), rng::size(vec_right),
                            _comm_rank + 1, &req_r);
     } else if (shift_right < 0) {
@@ -308,11 +314,11 @@ void shift_data(const int shift_left, const int shift_right,
 }
 
 template <typename valT>
-void copy_results(auto &lsegment, const int shift_left, const int shift_right,
-                  buffer<valT> &vec_recvdata, buffer<valT> &vec_left,
-                  buffer<valT> &vec_right) {
-  const std::size_t invalidate_left = std::max(-shift_left, 0);
-  const std::size_t invalidate_right = std::max(-shift_right, 0);
+void copy_results(auto &lsegment, const int64_t shift_left,
+                  const int64_t shift_right, buffer<valT> &vec_recvdata,
+                  buffer<valT> &vec_left, buffer<valT> &vec_right) {
+  const std::size_t invalidate_left = std::max(-shift_left, 0L);
+  const std::size_t invalidate_right = std::max(-shift_right, 0L);
 
   const std::size_t size_l = rng::size(vec_left);
   const std::size_t size_r = rng::size(vec_right);
@@ -370,13 +376,23 @@ void dist_sort(R &r, Compare &&comp) {
   std::vector<std::size_t> vec_recv_elems(_comm_size, 0);
   std::size_t _total_elems = 0;
 
+  fmt::print("{}:{} Dist sort, local segment size {}\n", default_comm().rank(),
+             __LINE__, rng::size(lsegment));
+
   __detail::local_sort(lsegment, comp);
 
   /* find splitting values - limits of areas to send to other processes */
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
+
   __detail::splitters<valT>(lsegment, comp, vec_split_i, vec_split_s);
+
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
+
   default_comm().alltoall(vec_split_s, vec_rsizes, 1);
 
   /* prepare data to send and receive */
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
+
   std::exclusive_scan(vec_rsizes.begin(), vec_rsizes.end(),
                       vec_rindices.begin(), 0);
   const std::size_t _recv_elems = vec_rindices.back() + vec_rsizes.back();
@@ -389,6 +405,8 @@ void dist_sort(R &r, Compare &&comp) {
    */
   // MPI_Request req_recvelems;
   // default_comm().i_all_gather(_recv_elems, vec_recv_elems, &req_recvelems);
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
+
   default_comm().all_gather(_recv_elems, vec_recv_elems);
 
   /* buffer for received data */
@@ -396,19 +414,26 @@ void dist_sort(R &r, Compare &&comp) {
 
   /* send data not belonging and receive data belonging to local  processes
    */
+  fmt::print("{}:{} alltoallv vec_split_s {} vec_split_i {} vec_rsizes {} "
+             "vec_rindices {}\n",
+             default_comm().rank(), __LINE__, vec_split_s, vec_split_i,
+             vec_rsizes, vec_rindices);
+
   default_comm().alltoallv(lsegment, vec_split_s, vec_split_i, vec_recvdata,
                            vec_rsizes, vec_rindices);
 
   /* TODO: vec recvdata is partially sorted, implementation of merge on GPU is
    * desirable */
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
   __detail::local_sort(vec_recvdata, comp);
-
+  assert(_is_sorted(vec_recvdata));
   // MPI_Wait(&req_recvelems, MPI_STATUS_IGNORE);
 
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
   _total_elems = std::reduce(vec_recv_elems.begin(), vec_recv_elems.end());
 
   /* prepare data for shift to neighboring processes */
-  std::vector<int> vec_shift(_comm_size - 1);
+  std::vector<int64_t> vec_shift(_comm_size - 1);
 
   const auto desired_elems_num = (_total_elems + _comm_size - 1) / _comm_size;
 
@@ -417,19 +442,21 @@ void dist_sort(R &r, Compare &&comp) {
     vec_shift[_i] = vec_shift[_i - 1] + desired_elems_num - vec_recv_elems[_i];
   }
 
-  const int shift_left = _comm_rank == 0 ? 0 : -vec_shift[_comm_rank - 1];
-  const int shift_right =
+  const int64_t shift_left = _comm_rank == 0 ? 0 : -vec_shift[_comm_rank - 1];
+  const int64_t shift_right =
       _comm_rank == _comm_size - 1 ? 0 : vec_shift[_comm_rank];
 
-  buffer<valT> vec_left(std::max(shift_left, 0));
-  buffer<valT> vec_right(std::max(shift_right, 0));
+  buffer<valT> vec_left(std::max(shift_left, 0L));
+  buffer<valT> vec_right(std::max(shift_right, 0L));
 
   /* shift data if necessary, to have exactly the number of elements equal to
    * lsegment size */
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
   __detail::shift_data<valT>(shift_left, shift_right, vec_recvdata, vec_left,
                              vec_right);
-
+  assert(_is_sorted(vec_recvdata));
   /* copy results to distributed vector's local segment */
+  fmt::print("{}:{} dist_sort\n", default_comm().rank(), __LINE__);
   __detail::copy_results<valT>(lsegment, shift_left, shift_right, vec_recvdata,
                                vec_left, vec_right);
 
@@ -446,6 +473,7 @@ void sort(R &r, Compare &&comp = Compare()) {
   std::size_t _comm_size = default_comm().size(); // dr-style ignore
 
   if (_comm_size == 1) {
+    DRLOG("mhp::sort() - one node only");
     auto &&lsegment = local_segment(r);
     __detail::local_sort(lsegment, comp);
 
@@ -453,7 +481,7 @@ void sort(R &r, Compare &&comp = Compare()) {
     /* Distributed vector of size <= (comm_size-1) * (comm_size-1) may have
      * 0-size local segments. It is also small enough to prefer sequential sort
      */
-    DRLOG("mhp::sort() - local sort");
+    DRLOG("mhp::sort() - local sort on node 0");
 
     std::vector<valT> vec_recvdata(rng::size(r));
     dr::mhp::copy(0, r, rng::begin(vec_recvdata));

--- a/include/dr/mhp/algorithms/sort.hpp
+++ b/include/dr/mhp/algorithms/sort.hpp
@@ -24,10 +24,6 @@
 
 namespace dr::mhp {
 
-bool _is_sorted(std::ranges::forward_range auto &r) {
-  return std::is_sorted(dpl_policy(), rng::begin(r), rng::end(r));
-}
-
 namespace __detail {
 
 template <typename T> class buffer {
@@ -137,7 +133,6 @@ template <typename R, typename Compare> void local_sort(R &r, Compare &&comp) {
       DRLOG("cpu rng::sort, size {}", rng::size(r));
       rng::sort(rng::begin(r), rng::end(r), comp);
     }
-    assert(_is_sorted(r));
   }
 }
 

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -38,7 +38,8 @@ public:
           "segm_offset:{}, size:{}, peer:{})",
           dst, offset, datalen, segment_index);
 
-#if MPI_SUPPORTS_RGET_C
+#if (MPI_VERSION >= 4) ||                                                        \
+      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     // 64-bit API inside
     win_.get(dst, datalen, segment_index, offset);
 #else
@@ -59,7 +60,8 @@ public:
           "src:{}, size:{}, peer:{})",
           offset, src, datalen, segment_index);
 
-#if MPI_SUPPORTS_RGET_C
+#if (MPI_VERSION >= 4) ||                                                        \
+      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     // 64-bit API inside
     win_.put(src, datalen, segment_index, offset);
 #else

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -40,13 +40,14 @@ public:
 
 #if (MPI_VERSION >= 4) ||                                                      \
     (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+    // 64-bit API inside
     win_.get(dst, datalen, segment_index, offset);
 #else
     for (std::size_t remainder = datalen, off = 0UL; remainder > 0;) {
       std::size_t s = std::min(remainder, (std::size_t)INT_MAX);
       DRLOG("{}:{} win_.get total {} now {} bytes at off {}, dst offset {}",
             default_comm().rank(), __LINE__, datalen, s, off, offset + off);
-      win_.get((char *)dst + off, s, segment_index, offset + off);
+      win_.get((uint8_t *)dst + off, s, segment_index, offset + off);
       off += s;
       remainder -= s;
     }
@@ -61,13 +62,14 @@ public:
 
 #if (MPI_VERSION >= 4) ||                                                      \
     (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+    // 64-bit API inside
     win_.put(src, datalen, segment_index, offset);
 #else
     for (std::size_t remainder = datalen, off = 0UL; remainder > 0;) {
       std::size_t s = std::min(remainder, (std::size_t)INT_MAX);
       DRLOG("{}:{} win_.put {} bytes at off {}, dst offset {}",
             default_comm().rank(), __LINE__, s, off, offset + off);
-      win_.put((char *)src + off, s, segment_index, offset + off);
+      win_.put((uint8_t *)src + off, s, segment_index, offset + off);
       off += s;
       remainder -= s;
     }

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -38,8 +38,7 @@ public:
           "segm_offset:{}, size:{}, peer:{})",
           dst, offset, datalen, segment_index);
 
-#if (MPI_VERSION >= 4) ||                                                      \
-    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if MPI_SUPPORTS_RGET_C
     // 64-bit API inside
     win_.get(dst, datalen, segment_index, offset);
 #else
@@ -60,8 +59,7 @@ public:
           "src:{}, size:{}, peer:{})",
           offset, src, datalen, segment_index);
 
-#if (MPI_VERSION >= 4) ||                                                      \
-    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if MPI_SUPPORTS_RGET_C
     // 64-bit API inside
     win_.put(src, datalen, segment_index, offset);
 #else
@@ -73,7 +71,6 @@ public:
       off += s;
       remainder -= s;
     }
-
 #endif
   }
 

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -38,7 +38,19 @@ public:
           "segm_offset:{}, size:{}, peer:{})",
           dst, offset, datalen, segment_index);
 
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     win_.get(dst, datalen, segment_index, offset);
+#else
+    for (std::size_t remainder = datalen, off = 0UL; remainder > 0;) {
+      std::size_t s = std::min(remainder, (std::size_t)INT_MAX);
+      DRLOG("{}:{} win_.get total {} now {} bytes at off {}, dst offset {}",
+            default_comm().rank(), __LINE__, datalen, s, off, offset + off);
+      win_.get((char *)dst + off, s, segment_index, offset + off);
+      off += s;
+      remainder -= s;
+    }
+#endif
   }
 
   void putmem(void const *src, std::size_t offset, std::size_t datalen,
@@ -46,7 +58,21 @@ public:
     DRLOG("calling MPI put(segm_offset:{}, "
           "src:{}, size:{}, peer:{})",
           offset, src, datalen, segment_index);
+
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     win_.put(src, datalen, segment_index, offset);
+#else
+    for (std::size_t remainder = datalen, off = 0UL; remainder > 0;) {
+      std::size_t s = std::min(remainder, (std::size_t)INT_MAX);
+      DRLOG("{}:{} win_.put {} bytes at off {}, dst offset {}",
+            default_comm().rank(), __LINE__, s, off, offset + off);
+      win_.put((char *)src + off, s, segment_index, offset + off);
+      off += s;
+      remainder -= s;
+    }
+
+#endif
   }
 
   std::size_t getrank() { return win_.communicator().rank(); }

--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -38,8 +38,8 @@ public:
           "segm_offset:{}, size:{}, peer:{})",
           dst, offset, datalen, segment_index);
 
-#if (MPI_VERSION >= 4) ||                                                        \
-      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     // 64-bit API inside
     win_.get(dst, datalen, segment_index, offset);
 #else
@@ -60,8 +60,8 @@ public:
           "src:{}, size:{}, peer:{})",
           offset, src, datalen, segment_index);
 
-#if (MPI_VERSION >= 4) ||                                                        \
-      (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
+#if (MPI_VERSION >= 4) ||                                                      \
+    (defined(I_MPI_NUMVERSION) && (I_MPI_NUMVERSION > 20211200000))
     // 64-bit API inside
     win_.put(src, datalen, segment_index, offset);
 #else

--- a/test/gtest/common/sort.cpp
+++ b/test/gtest/common/sort.cpp
@@ -46,8 +46,6 @@ TEST(Sort, Random_dist_small) { test_sort_randomvec(17); }
 
 TEST(Sort, Random_dist_med) { test_sort_randomvec(123); }
 
-TEST(Sort, Random_dist_big64) { test_sort_randomvec(4000000000); }
-
 TEST(Sort, AllSame) {
   test_sort2s({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
 }

--- a/test/gtest/common/sort.cpp
+++ b/test/gtest/common/sort.cpp
@@ -46,6 +46,8 @@ TEST(Sort, Random_dist_small) { test_sort_randomvec(17); }
 
 TEST(Sort, Random_dist_med) { test_sort_randomvec(123); }
 
+TEST(Sort, Random_dist_big64) { test_sort_randomvec(4000000000); }
+
 TEST(Sort, AllSame) {
   test_sort2s({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
 }


### PR DESCRIPTION
mhp::copy and mhp::sort updated to avoid 32-bit int limitations