### PR TITLE
treating warnings as errors no more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(GoogleTest)
 
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wall>)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror>)
+  # DR stopped to compile without warnings :(
+  # add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror>)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-error=stringop-overflow=)


### PR DESCRIPTION
It is due to warning in cpp-format. And in order to ease project maintenance.